### PR TITLE
chore: replace nbsp characters with normal space

### DIFF
--- a/deltakit-circuit/ruff.toml
+++ b/deltakit-circuit/ruff.toml
@@ -1,4 +1,4 @@
-# Linting configuration for deltakit_circuit.
+# Linting configuration for deltakit_circuit.
 #
 # General and format configurations are repository-wide for the moment.
 extend = "../ruff.toml"
@@ -9,32 +9,32 @@ ignore = []
 
 # Specific per-file ignores
 [lint.per-file-ignores]
-# Most of the gates are named in SCREAMING_SNAKE_CASE and that is expected.
+# Most of the gates are named in SCREAMING_SNAKE_CASE and that is expected.
 "src/deltakit_circuit/gates/*.py" = ["N801"]
 # We do not want to touch any module outside of deltakit-circuit for the moment,
 # and renaming the exception in the following file would do that so ignoring
-# for the moment.
+# for the moment.
 "src/deltakit_circuit/_parse_stim.py" = ["N818"]
-# For the moment, dynamic __all__ generation raises a lot of issues with 
+# For the moment, dynamic __all__ generation raises a lot of issues with
 # F401 enabled, so ignore it where it happens, in __init__.py files.
 "**/__init__.py" = ["F401"]
 
-# Test-specific ignores.
+# Test-specific ignores.
 "tests/**/*.py" = [    
-    # Some tests have long function names which exceeds the line length limit in order 
-    # to be descriptive. The names might also not respect the camel case requirement to
-    # include gate names in the function name. That is fine, so ignoring the respective
-    # errors.
+    # Some tests have long function names which exceeds the line length limit in order
+    # to be descriptive. The names might also not respect the camel case requirement to
+    # include gate names in the function name. That is fine, so ignoring the respective
+    # errors.
     "E501", 
     "N802",
-    # Magic constants in tests does not seem like an issue here.
+    # Magic constants in tests does not seem like an issue here.
     "PLR2004",
     # ruff reports "useless attribute access" on some code but the attribute access is
     # not really useless, as the goal is to call it and see if it raises an exception,
     # so this check is also ignored. 
     "B018"
 ]
-# One test checking for invalid parameters is basically catching on Exception. That is
-# needed because the exception raised in each cases may be different, and Exception is
-# the only common parent class of all of them.
+# One test checking for invalid parameters is basically catching on Exception. That is
+# needed because the exception raised in each cases may be different, and Exception is
+# the only common parent class of all of them.
 "tests/test_noise_channels/test_pauli_noise.py" = ["B017"]

--- a/deltakit-core/ruff.toml
+++ b/deltakit-core/ruff.toml
@@ -1,4 +1,4 @@
-# Linting configuration for deltakit_explorer.
+# Linting configuration for deltakit_explorer.
 #
 # General and format configurations are repository-wide for the moment.
 extend = "../ruff.toml"
@@ -7,13 +7,13 @@ include = ["src/deltakit_core/**/*.py", "tests/**/*.py"]
 # Specific per-file ignores
 [lint.per-file-ignores]
 "tests/**/*.py" = [
-    # Magic constants in tests are not an urgent issue.
+    # Magic constants in tests are not an urgent issue.
     "PLR2004",
-    # Some tests have long lines. That is mostly due to long and descriptive test names
+    # Some tests have long lines. That is mostly due to long and descriptive test names
     # which is a desirable feature. Removing that check for the tests only. 
     "E501",
     # Some test names/arguments are not strictly using camel_case as they contain some
-    # capitalised letters. This is not an issue as most of the time this casing helps
-    # with the readability.
+    # capitalised letters. This is not an issue as most of the time this casing helps
+    # with the readability.
     "N802", "N803"
 ]

--- a/deltakit-decode/ruff.toml
+++ b/deltakit-decode/ruff.toml
@@ -1,11 +1,11 @@
-# Linting configuration for deltakit_decode.
+# Linting configuration for deltakit_decode.
 #
 # General and format configurations are repository-wide for the moment.
 extend = "../ruff.toml"
 
 [lint]
 ignore = [
-    "B008",    # Default argument evaluation with class instantiation.
+    "B008",    # Default argument evaluation with class instantiation.
     "B905",    # Missing `strict` argument to `zip`
     "E501",    # line length > 88 (fix later)
     "PLR2004", # magic values, especially in tests
@@ -17,11 +17,11 @@ fixable = ["ALL"]
 unfixable = []
 
 [lint.per-file-ignores]
-# For the moment, dynamic __all__ generation raises a lot of issues with 
+# For the moment, dynamic __all__ generation raises a lot of issues with
 # F401 enabled, so ignore it where it happens, in __init__.py files.
 "__init__.py" = ["F401"]
-# The DecoderManager class needs a global variable for optimisation purposes. The goal
-# is to avoid to have to deepcopy the DecoderManager instance each time a new batch of
-# shots is required when performing computation with a process pool. For the moment,
+# The DecoderManager class needs a global variable for optimisation purposes. The goal
+# is to avoid to have to deepcopy the DecoderManager instance each time a new batch of
+# shots is required when performing computation with a process pool. For the moment,
 # we ignore specifically this error for that file.
 "src/deltakit_decode/analysis/_decoder_manager.py" = ["PLW0603"]

--- a/deltakit-explorer/ruff.toml
+++ b/deltakit-explorer/ruff.toml
@@ -1,4 +1,4 @@
-# Linting configuration for deltakit_explorer.
+# Linting configuration for deltakit_explorer.
 #
 # General and format configurations are repository-wide for the moment.
 extend = "../ruff.toml"

--- a/ruff.toml
+++ b/ruff.toml
@@ -46,7 +46,7 @@ exclude = [
     "_version.py",
 ]
 
-# Only include the deltakit folders, not the docs/, tools/ or
+# Only include the deltakit folders, not the docs/, tools/ or
 # other utility folder.
 include = ["deltakit-*/**/*.py", "src/deltakit/**/*.py"]
 


### PR DESCRIPTION
## 📝 Description

Some non-breaking space characters have been showing up. I'm not sure how to protect against them (e.g. they caused problems in a doc build, at one point) but this removes the ones we have now.

---

## 🚦 Status

Ready

---

## 🛠️ Future Work

Add tool that prevents them from being added?

---

## 🧾 Release Note

PR title
