### PR TITLE
feat(cancel): cancelling the job with Ctrl+C in APIv2

### DIFF
--- a/deltakit-explorer/src/deltakit_explorer/_api/_api_v2_client.py
+++ b/deltakit-explorer/src/deltakit_explorer/_api/_api_v2_client.py
@@ -206,7 +206,7 @@ class APIv2Client(APIClient):
             return job.result
         except KeyboardInterrupt:
             count = self.kill(job.request_id)
-            raise InterruptedError(f"Cancelled job {job.request_id}.")
+            raise InterruptedError(f"Cancelled job {job.request_id} ({count} worker(s)).")
 
     @override
     def kill(self, request_id: str) -> int:

--- a/deltakit-explorer/src/deltakit_explorer/_api/_api_v2_client.py
+++ b/deltakit-explorer/src/deltakit_explorer/_api/_api_v2_client.py
@@ -206,7 +206,7 @@ class APIv2Client(APIClient):
             return job.result
         except KeyboardInterrupt:
             count = self.kill(job.request_id)
-            raise InterruptedError(f"Cancelled {count} task(s).")
+            raise InterruptedError(f"Cancelled job {job.request_id}.")
 
     @override
     def kill(self, request_id: str) -> int:

--- a/deltakit-explorer/src/deltakit_explorer/_api/_api_v2_client.py
+++ b/deltakit-explorer/src/deltakit_explorer/_api/_api_v2_client.py
@@ -187,22 +187,26 @@ class APIv2Client(APIClient):
         request_id: str,
     ) -> dict[str, Any]:
         job = self._submit_task(query_name, variable_values, request_id)
-        # A client request ID is going to be different from
-        # a server-generated one.
-        Logging.info(f"Server created the job {job.request_id}", request_id)
-        while job.status in [JobStatus.SUBMITTED.value, JobStatus.IN_PROGRESS.value]:
-            time.sleep(APIv2Client.STATUS_CHECK_DELAY)
+        try:
+            # A client request ID is going to be different from
+            # a server-generated one.
+            Logging.info(f"Server created the job {job.request_id}", request_id)
+            while job.status in [JobStatus.SUBMITTED.value, JobStatus.IN_PROGRESS.value]:
+                time.sleep(APIv2Client.STATUS_CHECK_DELAY)
+                Logging.info(
+                    f"Job ({job.type}, {job.request_id}), status = {job.status}",
+                    request_id
+                )
+                job = self._get_job_status(job.request_id)
+            job.raise_on_error()
             Logging.info(
-                f"Job ({job.type}, {job.request_id}), status = {job.status}",
+                f"Job ({job.type}, {job.request_id}) completed, status = {job.status}",
                 request_id
             )
-            job = self._get_job_status(job.request_id)
-        job.raise_on_error()
-        Logging.info(
-            f"Job ({job.type}, {job.request_id}) completed, status = {job.status}",
-            request_id
-        )
-        return job.result
+            return job.result
+        except KeyboardInterrupt:
+            count = self.kill(job.request_id)
+            raise InterruptedError(f"Cancelled {count} task(s).")
 
     @override
     def kill(self, request_id: str) -> int:

--- a/deltakit-explorer/src/deltakit_explorer/_api/_api_v2_client.py
+++ b/deltakit-explorer/src/deltakit_explorer/_api/_api_v2_client.py
@@ -206,7 +206,9 @@ class APIv2Client(APIClient):
             return job.result
         except KeyboardInterrupt:
             count = self.kill(job.request_id)
-            raise InterruptedError(f"Cancelled job {job.request_id} ({count} worker(s)).")
+            raise InterruptedError(
+                f"Cancelled job {job.request_id} ({count} worker(s))."
+            )
 
     @override
     def kill(self, request_id: str) -> int:


### PR DESCRIPTION
## 🔗 Closed Issues

A bug from backlog 

---

## 📝 Description

This PR re-implements an approach already present in APIv1.
If the request is sent, we may cancel it by CTRL+C. In this case,
`KeyboardInterrupt` exception is raised. We handle this and try to
cancel the job on the client side. Then we replace exception with a
meaningful message.

---

## 🚦 Status

Done.

---

## 🛠️ Future Work

Follows by a PR on the server side.

---

## ➕️ Additional Information

N/A

---

## 🧾 Release Note

PR Title