### PR TITLE
chore: make bandit respect `pyproject.toml` configuration 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
     rev: 1.8.6
     hooks:
     - id: bandit
-      args: [--skip, B101, --exclude, tools/]
+      args: [-c, pyproject.toml]
 
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.24.1

--- a/deltakit-explorer/tests/server/test_gql_client.py
+++ b/deltakit-explorer/tests/server/test_gql_client.py
@@ -41,7 +41,7 @@ class TestGQLClient:
                 errors=[graphql.GraphQLError("some message")]
             )
         )
-        randint = random.randint(100000, 999999)  # nosec B311
+        randint = random.randint(100000, 999999)
         mocker.patch("deltakit_explorer._utils._utils.APP_NAME", f"deltakit-testplorer-{randint}")
 
         client = Client("http://localhost/", api_version=1)
@@ -55,7 +55,7 @@ class TestGQLClient:
             "gql.client.SyncClientSession.execute",
             side_effect=KeyboardInterrupt,
         )
-        randint = random.randint(100000, 999999)  # nosec B311
+        randint = random.randint(100000, 999999)
         mocker.patch(
             "deltakit_explorer._utils._utils.APP_NAME",
             f"deltakit-testplorer-{randint}"

--- a/deltakit-explorer/tests/server/test_token.py
+++ b/deltakit-explorer/tests/server/test_token.py
@@ -43,7 +43,7 @@ class TestGQLClientTokenManipulations:
             "deltakit_explorer._api._client.Client.get_instance",
             return_value=client,
         )
-        randint = random.randint(1000, 9999)  # nosec B311
+        randint = random.randint(1000, 9999)
         token = f"abc-{randint}"
         Client.set_token(token, validate=False)
         assert _auth.get_token() == token
@@ -56,7 +56,7 @@ class TestGQLClientTokenManipulations:
             return_value=client,
         )
         Path.unlink(utils.get_config_file_path())
-        randint = random.randint(1000, 9999)  # nosec B311
+        randint = random.randint(1000, 9999)
         token = f"abc-{randint}"
         GQLClient("http://localhost").set_token(token, validate=False)
         assert _auth.get_token() == token
@@ -69,7 +69,7 @@ class TestGQLClientTokenManipulations:
         )
         mocker.patch.object(client._api._request_session, "get", return_value=FakeResponse(404))
         Path.unlink(utils.get_config_file_path())
-        randint = random.randint(1000, 9999)  # nosec B311
+        randint = random.randint(1000, 9999)
         token = f"abc-{randint}"
         Client.set_token(token, validate=True)
         assert _auth.get_token() == token
@@ -82,7 +82,7 @@ class TestGQLClientTokenManipulations:
         )
         mocker.patch.object(client._api._request_session, "get", return_value=FakeResponse(403))
         Path.unlink(utils.get_config_file_path())
-        randint = random.randint(1000, 9999)  # nosec B311
+        randint = random.randint(1000, 9999)
         token = f"abc-{randint}"
         with pytest.raises(ServerException):
             Client.set_token(token, validate=True)

--- a/deltakit-explorer/tests/utils/test_auth.py
+++ b/deltakit-explorer/tests/utils/test_auth.py
@@ -12,7 +12,7 @@ from deltakit_explorer._utils import _utils as utils
 
 
 def test_set_token(mocker):
-    randint = random.randint(100000, 999999)  # nosec B311
+    randint = random.randint(100000, 999999)
     mocker.patch("deltakit_explorer._utils._utils.APP_NAME", f"qec-testplorer-{randint}")
     token = "2134"  # nosec B105
     _auth.set_token(token)
@@ -20,7 +20,7 @@ def test_set_token(mocker):
 
 
 def test_if_no_token_raises(mocker):
-    randint = random.randint(100000, 999999)  # nosec B311
+    randint = random.randint(100000, 999999)
     mocker.patch("deltakit_explorer._utils._utils.APP_NAME", f"qec-testplorer-{randint}")
     utils.override_persisted_variables({}, utils.get_config_file_path())
     os.environ.pop(_auth.TOKEN_VARIABLE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,8 @@ filterwarnings = [
 skip = [".pixi", ".tox", ".venv"]
 
 [tool.bandit]
-exclude_dirs = ['.github', '.pixi', '.tox', '.venv', './tools/vale.py']
+# './tools/vale.py' is for `pixi run bandit`; 'tools/vale.py' is for pre-commit
+exclude_dirs = ['.github', '.pixi', '.tox', '.venv', './tools/vale.py', 'tools/vale.py']
 skips = ['B101', 'B311']  # B101 is just use of `assert`; 'B311' is use of random module
 
 [tool.typos.default.extend-words]


### PR DESCRIPTION
## 🔗 Closed Issues

Toward gh-63

---

## 📝 Description

When run via `pre-commit`, bandit was not respecting `pyproject.toml` configuration. This adds the argument to make it do so.

---

## 🚦 Status

Ready for review.

---

## 🛠️ Future Work

The rest of gh-63!

---

## 🧾 Release Note

PR title is fine. The `B311` removals are very minor and also just "chores".