### PR TITLE
docs: organize deltakit decode/core namespace documentation

### DIFF
--- a/deltakit-core/src/deltakit_core/__init__.py
+++ b/deltakit-core/src/deltakit_core/__init__.py
@@ -1,5 +1,7 @@
 # (c) Copyright Riverlane 2020-2025.
-"""Description of ``deltakit.core`` namespace here."""
+"""
+Description of `deltakit.core` namespace here.
+"""
 
 import importlib.metadata
 

--- a/deltakit-core/src/deltakit_core/data_formats/__init__.py
+++ b/deltakit-core/src/deltakit_core/data_formats/__init__.py
@@ -1,6 +1,6 @@
 # (c) Copyright Riverlane 2020-2025.
 """
-Sub-package for data formats and converting them to other data types
+Sub-package for data formats and converting them to other data types.
 """
 
 from deltakit_core.data_formats._b801_parsers import (

--- a/deltakit-decode/src/deltakit_decode/__init__.py
+++ b/deltakit-decode/src/deltakit_decode/__init__.py
@@ -1,5 +1,7 @@
 # (c) Copyright Riverlane 2020-2025.
-"""Description of ``deltakit.decode`` namespace here."""
+"""
+Description of `deltakit.decode` namespace here.
+"""
 
 import importlib.metadata
 

--- a/deltakit-decode/src/deltakit_decode/analysis/__init__.py
+++ b/deltakit-decode/src/deltakit_decode/analysis/__init__.py
@@ -1,5 +1,7 @@
 # (c) Copyright Riverlane 2020-2025.
-"""Description of ``deltakit.decode.analysis`` namespace here."""
+"""
+Description of `deltakit.decode.analysis` namespace here.
+"""
 
 from deltakit_decode.analysis._decoder_manager import (
     DecoderManager, InvalidGlobalManagerStateError)

--- a/deltakit-decode/src/deltakit_decode/noise_sources/__init__.py
+++ b/deltakit-decode/src/deltakit_decode/noise_sources/__init__.py
@@ -2,6 +2,7 @@
 """
 Sub-package for defining sources of noise to be used in QEC experiments.
 """
+
 from deltakit_decode.noise_sources._generic_noise_sources import (
     CombinedIndependent, CombinedSequences, MonteCarloNoise, NoiseModel,
     SequentialNoise)

--- a/deltakit-decode/src/deltakit_decode/utils/__init__.py
+++ b/deltakit-decode/src/deltakit_decode/utils/__init__.py
@@ -1,5 +1,7 @@
 # (c) Copyright Riverlane 2020-2025.
-"""Description of ``deltakit.decode.utils`` namespace here."""
+"""
+Description of `deltakit.decode.utils` namespace here.
+"""
 
 from deltakit_decode.utils._decoding_graph_visualiser import VisDecodingGraph3D
 from deltakit_decode.utils._derivation_tools import (generate_expectation_data,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -269,58 +269,89 @@ Description of ``deltakit.core.data_formats`` namespace here.
 ``deltakit.core.decoding_graphs``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Description of ``deltakit.core.decoding_graphs`` namespace here.
+Sub-package for defining decoding graphs and related data types; these structures are
+used by many decoders to define their understanding of the code and noise model being
+decoded.
 
 .. currentmodule:: deltakit.core.decoding_graphs
+
+Decoding Graph Abstractions
+"""""""""""""""""""""""""""
 
 .. autosummary::
     :toctree: _build/generated/
 
-    AnyEdgeT
-    Bitstring
-    change_graph_error_probabilities
-    compute_graph_distance
-    compute_graph_distance_for_logical
-    DecodingCode
     DecodingEdge
     DecodingHyperEdge
+    EdgeRecord
+    OrderedDecodingEdges
+    DecodingCode
     DecodingHyperGraph
     DecodingHyperMultiGraph
-    decompositions
-    dem_to_decoding_graph_and_logicals
-    dem_to_hypergraph_and_logicals
-    DemParser
-    DetectorCounter
-    DetectorRecord
-    DetectorRecorder
-    EdgeRecord
-    EdgeT
-    errors_to_syndrome
-    extract_logicals
-    filter_to_data_edges
-    filter_to_measure_edges
-    FixedWidthBitstring
-    get_round_words
-    graph_to_json
-    has_contiguous_nodes
-    hypergraph_to_weighted_edge_list
     HyperLogicals
     HyperMultiGraph
-    inverse_logical_at_boundary
-    is_single_connected_component
-    LogicalsInEdges
     NXCode
     NXDecodingGraph
     NXDecodingMultiGraph
     NXLogicals
-    observable_warning
-    OrderedDecodingEdges
-    OrderedSyndrome
-    parse_explained_dem
+
+Decoding Graph Manipulation Tools
+"""""""""""""""""""""""""""""""""
+
+.. autosummary::
+    :toctree: _build/generated/
+
+    errors_to_syndrome
+    compute_graph_distance
+    compute_graph_distance_for_logical
+    filter_to_data_edges
+    filter_to_measure_edges
+    graph_to_json
+    has_contiguous_nodes
+    hypergraph_to_weighted_edge_list
+    inverse_logical_at_boundary
+    is_single_connected_component
     single_boundary_is_last_node
     unweight_graph
-    vector_weights
     worst_case_num_detectors
+    extract_logicals
+    change_graph_error_probabilities
+    vector_weights
+
+DEM → Decoding Graphs
+"""""""""""""""""""""
+
+.. autosummary::
+    :toctree: _build/generated/
+
+    dem_to_decoding_graph_and_logicals
+    dem_to_hypergraph_and_logicals
+    parse_explained_dem
+
+Decoding Graph Data Types
+"""""""""""""""""""""""""
+
+.. autosummary::
+    :toctree: _build/generated/
+
+    Bitstring
+    FixedWidthBitstring
+    DetectorRecord
+    OrderedSyndrome
+
+Other
+"""""
+
+    DemParser
+    DetectorRecorder
+    LogicalsInEdges
+    observable_warning
+    decompositions
+    split_measurement_bitstring
+    AnyEdgeT
+    DetectorCounter
+    EdgeT
+    get_round_words
 
 .. _api-deltakit-decode:
 
@@ -330,6 +361,9 @@ Description of ``deltakit.core.decoding_graphs`` namespace here.
 .. currentmodule:: deltakit.decode
 
 Description of ``deltakit.decode`` namespace here.
+
+Decoders
+^^^^^^^^
 
 .. autosummary::
     :toctree: _build/generated/
@@ -347,28 +381,28 @@ Description of ``deltakit.decode`` namespace here.
 ``deltakit.decode.analysis``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Description of ``deltakit.decode.analysis`` namespace here.
+Please describe ``deltakit.decode.analysis`` namespace here.
 
 .. currentmodule:: deltakit.decode.analysis
 
 .. autosummary::
     :toctree: _build/generated/
 
+    run_decoding_on_circuit
+    RunAllAnalysisEngine
     DecoderManager
     InvalidGlobalManagerStateError
-    run_decoding_on_circuit
     EmpiricalDecodingErrorDistribution
     B8DecoderManager
     GraphDecoderManager
     StimDecoderManager
-    RunAllAnalysisEngine
 
 .. _api-deltakit-decode-noise_sources:
 
 ``deltakit.decode.noise_sources``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Description of ``deltakit.decode.noise_sources`` namespace here.
+Sub-package for defining sources of noise to be used in QEC experiments.
 
 .. currentmodule:: deltakit.decode.noise_sources
 
@@ -399,6 +433,9 @@ Description of ``deltakit.decode.noise_sources`` namespace here.
 
 .. currentmodule:: deltakit.decode.utils
 
+Syndrome Data Tools
+"""""""""""""""""""
+
 .. autosummary::
     :toctree: _build/generated/
 
@@ -407,11 +444,18 @@ Description of ``deltakit.decode.noise_sources`` namespace here.
     create_dem_from_pij
     dem_and_pij_edges_max_diff
     generate_expectation_data
-    make_logger
-    parse_stim_circuit
     pij_and_dem_edge_diff
     pij_edges_max_diff
     pijs_edge_diff
+
+Other
+"""""
+
+.. autosummary::
+    :toctree: _build/generated/
+
+    make_logger
+    parse_stim_circuit
     plot_correlation_matrix
     split_measurement_bitstring
     VisDecodingGraph3D

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -73,8 +73,8 @@ Circuit Manipulation and Noise Generation
     measurement_noise_profile
     noise_profile_with_inverted_noise
 
-Other
-"""""
+Other Circuit Features
+""""""""""""""""""""""
 
 .. autosummary::
     :toctree: _build/generated/
@@ -339,8 +339,8 @@ Decoding Graph Data Types
     DetectorRecord
     OrderedSyndrome
 
-Other
-"""""
+Other Decoding Graph Features
+"""""""""""""""""""""""""""""
 
     DemParser
     DetectorRecorder
@@ -448,8 +448,8 @@ Syndrome Data Tools
     pij_edges_max_diff
     pijs_edge_diff
 
-Other
-"""""
+Other Decoding Utilities
+""""""""""""""""""""""""
 
 .. autosummary::
     :toctree: _build/generated/

--- a/src/deltakit/core/__init__.py
+++ b/src/deltakit/core/__init__.py
@@ -1,3 +1,8 @@
+# (c) Copyright Riverlane 2020-2025.
+"""
+Please describe `deltakit.core` namespace here.
+"""
+
 from deltakit_core import *  # noqa: F403
 
 # List only public members in `__all__`.

--- a/src/deltakit/core/data_formats/__init__.py
+++ b/src/deltakit/core/data_formats/__init__.py
@@ -1,3 +1,8 @@
+# (c) Copyright Riverlane 2020-2025.
+"""
+Sub-package for data formats and converting them to other data types
+"""
+
 from deltakit_core.data_formats import *  # noqa: F403
 
 # List only public members in `__all__`.

--- a/src/deltakit/core/decoding_graphs/__init__.py
+++ b/src/deltakit/core/decoding_graphs/__init__.py
@@ -1,3 +1,10 @@
+# (c) Copyright Riverlane 2020-2025.
+"""
+Sub-package for defining decoding graphs and related data types; these structures are
+used by many decoders to define their understanding of the code and noise model being
+decoded.
+"""
+
 from deltakit_core.decoding_graphs import *  # noqa: F403
 
 # List only public members in `__all__`.

--- a/src/deltakit/decode/__init__.py
+++ b/src/deltakit/decode/__init__.py
@@ -1,3 +1,8 @@
+# (c) Copyright Riverlane 2020-2025.
+"""
+Description of `deltakit.decode` namespace here.
+"""
+
 from deltakit_decode import *  # noqa: F403
 from deltakit_explorer._cloud_decoders import *  # noqa: F403
 

--- a/src/deltakit/decode/analysis/__init__.py
+++ b/src/deltakit/decode/analysis/__init__.py
@@ -1,3 +1,8 @@
+# (c) Copyright Riverlane 2020-2025.
+"""
+Description of `deltakit.decode.analysis` namespace here.
+"""
+
 from deltakit_decode.analysis import *  # noqa: F403
 
 # List only public members in `__all__`.

--- a/src/deltakit/decode/noise_sources/__init__.py
+++ b/src/deltakit/decode/noise_sources/__init__.py
@@ -1,3 +1,8 @@
+# (c) Copyright Riverlane 2020-2025.
+"""
+Sub-package for defining sources of noise to be used in QEC experiments.
+"""
+
 from deltakit_decode.noise_sources import *  # noqa: F403
 
 # List only public members in `__all__`.

--- a/src/deltakit/decode/utils/__init__.py
+++ b/src/deltakit/decode/utils/__init__.py
@@ -1,3 +1,8 @@
+# (c) Copyright Riverlane 2020-2025.
+"""
+Description of `deltakit.decode.utils` namespace here.
+"""
+
 from deltakit_decode.utils import *  # noqa: F403
 
 # List only public members in `__all__`.


### PR DESCRIPTION
## 🔗 Closed Issues

Toward gh-35

---

## 📝 Description

gh-227 began to add headings and organization to `deltakit.circuit`. This issue works on `deltakit.core` and `deltakit.decode`.

---

## 🚦 Status

Ready for merge. After revieew in https://github.com/riverlane/deltakit/pull/292, I used `git diff > my_changes.patch` and `git apply > my_changes.patch` to move the changes to this repo, so they should be copied verbatim. The second commit makes the headings of the "Other" sections distinct to avoid a doc build warning.

Before merge, this still need top-level descriptions of packages (e.g. replace "Description of `deltakit.core` namespace here.").

---

## ➕️ Additional Information

This PR has already been approved by @nelimee and @theinsanetramp internally, but additional reviews are welcome. 

---

## 🧾 Release Note

PR title