### PR TITLE
chore: configure ruff format to run with pre-commit, ci

### DIFF
--- a/.github/workflows/static_code_analysis.yml
+++ b/.github/workflows/static_code_analysis.yml
@@ -37,8 +37,12 @@ jobs:
       - name: typos
         run: pixi run typos
 
-      - name: ruff
+      - name: ruff check
         run: pixi run lint
+        if: ${{ always() }}
+
+      - name: ruff format
+        run: pixi run ruff format --check
         if: ${{ always() }}
 
       - name: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       # - id: ruff-format
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.34.0
+    rev: v1.37.1
     hooks:
       - id: typos
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -48,7 +48,7 @@ exclude = [
 
 # Only include the deltakit folders, not the docs/, tools/ or
 # other utility folder.
-include = ["deltakit-*/**/*.py", "src/deltakit/**/*.py"]
+include = ["deltakit-*/**/*.py", "src/deltakit/**/*.py", "tools/**/*.py", "tests/**/*.py"]
 
 # Same as Black.
 line-length = 88
@@ -69,6 +69,9 @@ select = ["A", "B", "E", "F", "N", "PL", "RUF100", "W", "NPY"]
 ]
 
 [format]
+# These packages don't want to use ruff format yet
+exclude = ["deltakit-explorer/**", "./deltakit-decode/**"]
+
 # Like Black, use double quotes for strings.
 quote-style = "double"
 


### PR DESCRIPTION
## 🔗 Closed Issues

Closes gh-63
Supersedes gh-69

---

## 📝 Description

Previously, `ruff format` was run manually on `deltakit-circuit` and `deltakit-core`, and there were a few follow-up PRs that manually re-ran it. This PR:
- configures `ruff format` to run on the files we want, excluding `deltakit-explorer` and `deltakit-decode` (for now)
- runs `ruff format` in pre-commit
- runs `ruff format --check` in CI
- formats the `/tools` and `/tests` folders with `ruff format`
- fixes a few `ruff check` issues identified in `/tools` and `/tests` by `pre-commit`

---

## 🚦 Status

Not done.

---

## 🧾 Release Note

PR title.
