### PR TITLE
chore: ignore `pip` vulnerability reported by `pip-audit`

### DIFF
--- a/.github/workflows/static_code_analysis.yml
+++ b/.github/workflows/static_code_analysis.yml
@@ -58,5 +58,5 @@ jobs:
         if: ${{ always() }}
 
       - name: pip_audit
-        run: pixi run pip_audit
+        run: pixi run pip_audit --ignore-vuln GHSA-4xh5-x5gv-qwph
         if: ${{ always() }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,8 @@ dev = [
     "python-semantic-release>=10.2.0",
     "tomlkit>=0.13,<1",
     "deptry>=0.23, <1",
-    "ipykernel >=6.29.5,<7"
+    "ipykernel >=6.29.5,<7",
+    "pip!=25.2",
 ]
 
 # for mypy configuration, see `mypy.ini`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,6 @@ dev = [
     "tomlkit>=0.13,<1",
     "deptry>=0.23, <1",
     "ipykernel >=6.29.5,<7",
-    "pip!=25.2",
 ]
 
 # for mypy configuration, see `mypy.ini`.


### PR DESCRIPTION
## 📝 Description

The Static Code Analysis workflow is failing in all PRs right now due to a vulnerability with `pip` reported by `pip-audit`.

```
Found 1 known vulnerability in 1 package  
Name Version ID Fix Versions  
pip  25.2    GHSA-4xh5-x5gv-qwph
```

This issue is documented in https://github.com/pypa/pip/issues/13607. I think we're waiting on a fix from `pip`; until then, this PR ignores the vulnerability.

---

## 🚦 Status

Ready for review.

---

## 🛠️ Future Work

After merge, open a reminder issue to check for updates.

---

## 🧾 Release Note

PR title.