### PR TITLE
chore: simplify .readthedocs.yaml; add `-W` (fail on warnings) to custom build command

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,11 +9,9 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.13"
-
-python:
-  install:
-    - method: pip
-      path: .[docs]
+  commands:
+    - curl -sSf https://pixi.sh/install.sh | sh
+    - /home/docs/.pixi/bin/pixi run sphinx-build -T -W -n -b html -d _build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,9 +9,11 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.13"
-  commands:
-    - curl -sSf https://pixi.sh/install.sh | sh
-    - /home/docs/.pixi/bin/pixi run sphinx-build -T -b html -d _build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
+
+python:
+  install:
+    - method: pip
+      path: .[docs]
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,10 +11,4 @@ build:
     python: "3.13"
   commands:
     - curl -sSf https://pixi.sh/install.sh | sh
-    - /home/docs/.pixi/bin/pixi run sphinx-build -T -W -n -b html -d _build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
-
-# Build documentation in the "docs/" directory with Sphinx
-sphinx:
-  builder: html
-  configuration: docs/conf.py
-  fail_on_warning: true
+    - /home/docs/.pixi/bin/pixi run sphinx-build -T -W -b html -d _build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html


### PR DESCRIPTION
Closes gh-14

## 📝 Description

Read the Docs is not respecting the `fail_on_warning: true` setting because we're using a custom doc build command. The simplest fix is to add `-W` in the custom build command, but I'd like to see if I can remove the custom build command.

---

## 🚦 Status

Draft/testing

## 🧾 Release Note

PR title