### PR TITLE
tests: allow `pytest` to run from top level

### DIFF
--- a/deltakit-decode/tests/__init__.py
+++ b/deltakit-decode/tests/__init__.py
@@ -1,1 +1,0 @@
-# (c) Copyright Riverlane 2020-2025.

--- a/deltakit-explorer/tests/__init__.py
+++ b/deltakit-explorer/tests/__init__.py
@@ -1,1 +1,0 @@
-# (c) Copyright Riverlane 2020-2025.

--- a/deltakit-explorer/tests/helpers/__init__.py
+++ b/deltakit-explorer/tests/helpers/__init__.py
@@ -1,1 +1,0 @@
-# (c) Copyright Riverlane 2020-2025.


### PR DESCRIPTION
## 📝 Description

`pytest` / `pixi run pytest` did not run properly from the top level of the repository. This fixes it so all tests in all packages run.

---

## 🚦 Status

Ready to review

---

## 🧾 Release Note

PR title
