### PR TITLE
Add mypy_path to fix pre-commit

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
-
+; Make sure that mypy is always picking up deltakit* repositories
+mypy_path="$MYPY_CONFIG_FILE_DIR/src/:$MYPY_CONFIG_FILE_DIR/deltakit-core/src/:$MYPY_CONFIG_FILE_DIR/deltakit-circuit/src/:$MYPY_CONFIG_FILE_DIR/deltakit-decode/src/:$MYPY_CONFIG_FILE_DIR/deltakit-explorer/src/"
 ; strict option settings that we pass
 allow_untyped_globals = false
 allow_redefinition = false


### PR DESCRIPTION
## 🔗 Closed Issues

Quick fix for an issue introduced in #95

---

## 📝 Description

When used in `pre-commit`, `mypy` is only given the files that have been changed in the current commit.
That means that it does not have access to all deltakit* code, because deltakit is not installed in the pre-commit container.

This PR fixes that by adding all deltakit* source directories to `mypy_path`.

---

## 🚦 Status

Ready to merge

---

## 🛠️ Future Work

None

---

## ➕️ Additional Information

None

---

## 🧾 Release Note

PR title