### PR TITLE
DEV: add upper bound on supported Python

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
 
       - name: Set up Pixi
         uses: prefix-dev/setup-pixi@v0.8.10

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,9 +29,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Pixi
-        uses: prefix-dev/setup-pixi@v0.8.10
+        uses: prefix-dev/setup-pixi@v0.9.1
         with:
-          pixi-version: v0.50.2
+          pixi-version: v0.56.0
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,11 +28,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
       - name: Set up Pixi
         uses: prefix-dev/setup-pixi@v0.8.10
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.13'
 
       - name: Set up Pixi
         uses: prefix-dev/setup-pixi@v0.8.10

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
+          python-version: '3.x'
 
       - name: Set up Pixi
         uses: prefix-dev/setup-pixi@v0.8.10

--- a/.github/workflows/labeled_tests.yml
+++ b/.github/workflows/labeled_tests.yml
@@ -44,11 +44,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version.version }}
-
       - name: Set up Pixi
         uses: prefix-dev/setup-pixi@v0.9.1
         with:

--- a/.github/workflows/labeled_tests.yml
+++ b/.github/workflows/labeled_tests.yml
@@ -50,9 +50,9 @@ jobs:
           python-version: ${{ matrix.python-version.version }}
 
       - name: Set up Pixi
-        uses: prefix-dev/setup-pixi@v0.8.10
+        uses: prefix-dev/setup-pixi@v0.9.1
         with:
-          pixi-version: v0.49.0
+          pixi-version: v0.56.0
 
       - name: Instruct pixi to use specified Python version
         run: pixi add python=${{ matrix.python-version.version }}

--- a/.github/workflows/labeled_tests.yml
+++ b/.github/workflows/labeled_tests.yml
@@ -49,8 +49,5 @@ jobs:
         with:
           pixi-version: v0.56.0
 
-      - name: Instruct pixi to use specified Python version
-        run: pixi add python=${{ matrix.python-version.version }}
-
       - name: Run ${{ matrix.package }} tests
         run: pixi run -e ${{ matrix.package }}-tests-py${{ matrix.python-version.label }} tests

--- a/.github/workflows/static_code_analysis.yml
+++ b/.github/workflows/static_code_analysis.yml
@@ -21,11 +21,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
       - name: Set up Pixi
         uses: prefix-dev/setup-pixi@v0.8.10
         with:

--- a/.github/workflows/static_code_analysis.yml
+++ b/.github/workflows/static_code_analysis.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Pixi
-        uses: prefix-dev/setup-pixi@v0.8.10
+        uses: prefix-dev/setup-pixi@v0.9.1
         with:
-          pixi-version: v0.49.0
+          pixi-version: v0.56.0
 
       - name: Install dependencies
         run: pixi install

--- a/.github/workflows/static_code_analysis.yml
+++ b/.github/workflows/static_code_analysis.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.x'
 
       - name: Set up Pixi
         uses: prefix-dev/setup-pixi@v0.8.10

--- a/.github/workflows/static_code_analysis.yml
+++ b/.github/workflows/static_code_analysis.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.13'
 
       - name: Set up Pixi
         uses: prefix-dev/setup-pixi@v0.8.10

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,8 +7,6 @@ version: 2
 # Set the OS, Python version, and other tools you might need
 build:
   os: ubuntu-24.04
-  tools:
-    python: "3.13"
   commands:
     - curl -sSf https://pixi.sh/install.sh | sh
     - /home/docs/.pixi/bin/pixi run sphinx-build -T -W -b html -d _build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html

--- a/pixi.toml
+++ b/pixi.toml
@@ -116,7 +116,7 @@ cmd = "isort ."
 
 [dependencies]
 pandoc = ">=3.7.0.2,<4"
-python = ">=3.10,<3.14"
+python = ">=3.10"  # ,<3.14"
 actionlint = ">=1.7"
 pixi-pycharm = ">=0.0.8,<0.0.9"
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -116,7 +116,7 @@ cmd = "isort ."
 
 [dependencies]
 pandoc = ">=3.7.0.2,<4"
-python = ">=3.10"
+python = ">=3.10,<3.14"
 actionlint = ">=1.7"
 pixi-pycharm = ">=0.0.8,<0.0.9"
 
@@ -128,7 +128,7 @@ deltakit-explorer = { path = "./deltakit-explorer/", editable = true }
 deltakit = { path = "./", editable = true, extras=["dev"] }
 
 [feature.python.dependencies]
-python = ">=3.10,<=3.13"
+python = ">=3.10,<3.14"
 
 [feature.py310.dependencies]
 python = "3.10.*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -116,7 +116,7 @@ cmd = "isort ."
 
 [dependencies]
 pandoc = ">=3.7.0.2,<4"
-python = ">=3.10,<=3.13"
+python = ">=3.10"
 actionlint = ">=1.7"
 pixi-pycharm = ">=0.0.8,<0.0.9"
 
@@ -128,7 +128,7 @@ deltakit-explorer = { path = "./deltakit-explorer/", editable = true }
 deltakit = { path = "./", editable = true, extras=["dev"] }
 
 [feature.python.dependencies]
-python = ">=3.10"
+python = ">=3.10,<=3.13"
 
 [feature.py310.dependencies]
 python = "3.10.*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -128,7 +128,7 @@ deltakit-explorer = { path = "./deltakit-explorer/", editable = true }
 deltakit = { path = "./", editable = true, extras=["dev"] }
 
 [feature.python.dependencies]
-python = ">=3.10,<=3.13"
+python = ">=3.10"
 
 [feature.py310.dependencies]
 python = "3.10.*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -116,7 +116,7 @@ cmd = "isort ."
 
 [dependencies]
 pandoc = ">=3.7.0.2,<4"
-python = ">=3.10"  # ,<3.14"
+python = ">=3.10,<3.14"
 actionlint = ">=1.7"
 pixi-pycharm = ">=0.0.8,<0.0.9"
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -116,7 +116,7 @@ cmd = "isort ."
 
 [dependencies]
 pandoc = ">=3.7.0.2,<4"
-python = ">=3.10"
+python = ">=3.10,<=3.13"
 actionlint = ">=1.7"
 pixi-pycharm = ">=0.0.8,<0.0.9"
 
@@ -128,7 +128,7 @@ deltakit-explorer = { path = "./deltakit-explorer/", editable = true }
 deltakit = { path = "./", editable = true, extras=["dev"] }
 
 [feature.python.dependencies]
-python = ">=3.10"
+python = ">=3.10,<=3.13"
 
 [feature.py310.dependencies]
 python = "3.10.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "deltakit"
 version = "0.5.1"
 description = "Deltakit SDK"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<=3.13"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "deltakit"
 version = "0.5.1"
 description = "Deltakit SDK"
 readme = "README.md"
-requires-python = ">=3.10,<=3.13"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 


### PR DESCRIPTION
## 📝 Description

The Python 3.14 release is causing CI failures because there are some places where our Python version is unconstrained. When Python 3.14 gets installed before other packages, some other packages can't be installed.  This fixes the problem by adding an upper bound to Python version where needed.

---

## 🚦 Status

Ready for review.
---

## 🧾 Release Note

PR title