### PR TITLE
chore: temporary bposd version change

### DIFF
--- a/deltakit-explorer/pyproject.toml
+++ b/deltakit-explorer/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "requests_toolbelt >=1.0.0",  # needed by gql, which doesn't automatically install it
     "pymatching >= 2.2.2",
     "galois >= 0.4.6",
-    "bposd >= 2.1",
+    "bposd @ git+https://github.com/quantumgizmos/bp_osd.git@8894ec654b24ae875c07e5a361dcae9a77d748ce",
     "pandas >= 2.0",
     "pandas-stubs",
     "types-seaborn",


### PR DESCRIPTION
## 🔗 Closed Issues

This temporary fix #121.

---

## 📝 Description

Depends on a specific commit that fixes #121 that is blocking most PRs. Will need to be rolled-back when a version of `bposd` with that change is published to PyPI.

---

## 🚦 Status

Ready to merge.

---

## 🛠️ Future Work

Undo that change to depend on a version of `bposd` published on PyPI.

---

## ➕️ Additional Information

None

---

## 🧾 Release Note

PR title