### PR TITLE
fix: mypy error on imported symbol

### DIFF
--- a/deltakit-explorer/src/deltakit_explorer/codes/_css/_css_code_experiment_circuit.py
+++ b/deltakit-explorer/src/deltakit_explorer/codes/_css/_css_code_experiment_circuit.py
@@ -24,6 +24,8 @@ from deltakit_explorer.codes._planar_code._unrotated_planar_code import \
 from deltakit_explorer.codes._planar_code._unrotated_toric_code import \
     UnrotatedToricCode
 from deltakit_explorer.codes._repetition_code import RepetitionCode
+from deltakit_explorer.enums import QECECodeType, QECExperimentType
+from deltakit_explorer.types import CircuitParameters, QECExperimentDefinition
 
 
 def css_code_memory_circuit(
@@ -74,7 +76,7 @@ def css_code_memory_circuit(
         msg = "`use_iswap_gates == True` is only supported when a `client` object is provided."
         raise NotImplementedError(msg)
     if client is not None:
-        return _cloud_css_code_experiment_circuit(deltakit_explorer.enums.QECExperimentType.QUANTUM_MEMORY,
+        return _cloud_css_code_experiment_circuit(QECExperimentType.QUANTUM_MEMORY,
                                               css_code, num_rounds, logical_basis, client, use_iswap_gates)
     data_qubit_init_stage = (
         css_code.encode_logical_zeroes()
@@ -93,7 +95,7 @@ def css_code_memory_circuit(
 
 
 def _cloud_css_code_experiment_circuit(
-    experiment_type: deltakit_explorer.enums.QECExperimentType,
+    experiment_type: QECExperimentType,
     css_code: StabiliserCode,
     num_rounds: int,
     logical_basis: PauliBasis,
@@ -142,24 +144,24 @@ def _cloud_css_code_experiment_circuit(
         raise NotImplementedError(msg)
 
     code_types = {
-        RotatedPlanarCode: deltakit_explorer.enums.QECECodeType.ROTATED_PLANAR,
-        UnrotatedPlanarCode: deltakit_explorer.enums.QECECodeType.UNROTATED_PLANAR,
-        UnrotatedToricCode: deltakit_explorer.enums.QECECodeType.UNROTATED_TORIC,
-        RepetitionCode: deltakit_explorer.enums.QECECodeType.REPETITION,
-        BivariateBicycleCode: deltakit_explorer.enums.QECECodeType.BIVARIATE_BICYCLE,
+        RotatedPlanarCode: QECECodeType.ROTATED_PLANAR,
+        UnrotatedPlanarCode: QECECodeType.UNROTATED_PLANAR,
+        UnrotatedToricCode: QECECodeType.UNROTATED_TORIC,
+        RepetitionCode: QECECodeType.REPETITION,
+        BivariateBicycleCode: QECECodeType.BIVARIATE_BICYCLE,
     }
     code_type = code_types[css_code.__class__]
 
     if isinstance(css_code, PlanarCode):
-        parameters = deltakit_explorer.types.CircuitParameters.from_sizes(
+        parameters = CircuitParameters.from_sizes(
             (css_code.width, css_code.height)
         )
     elif isinstance(css_code, RepetitionCode):
-        parameters = deltakit_explorer.types.CircuitParameters.from_sizes(
+        parameters = CircuitParameters.from_sizes(
             (css_code.distance,)
         )
     elif isinstance(css_code, BivariateBicycleCode):
-        parameters=deltakit_explorer.types.CircuitParameters.from_matrix_specification(
+        parameters=CircuitParameters.from_matrix_specification(
             param_l=css_code.param_l,
             param_m=css_code.param_m,
             m_A_powers=css_code.m_A_powers,
@@ -178,7 +180,7 @@ def _cloud_css_code_experiment_circuit(
         ]
 
     circuit = client.generate_circuit(
-        deltakit_explorer.types.QECExperimentDefinition(
+        QECExperimentDefinition(
             experiment_type=experiment_type,
             code_type=code_type,
             observable_basis=logical_basis,
@@ -229,5 +231,5 @@ def css_code_stability_circuit(
     ValueError :
         If `css_code` is not of a valid type.
     """
-    return _cloud_css_code_experiment_circuit(deltakit_explorer.enums.QECExperimentType.STABILITY,
+    return _cloud_css_code_experiment_circuit(QECExperimentType.STABILITY,
                                               css_code, num_rounds, logical_basis, client, use_iswap_gates)


### PR DESCRIPTION
## 🔗 Closed Issues

Closes #140

---

## 📝 Description

Correctly imports the `QECExperimentType` object. Also remove all the `[module].[object]` directly from the code by:

1. add a `from [module] import [object]`
2. replace the `[module].[object]` part with simply `[object]`.

---

## 🚦 Status

Ready to merge

---

## 🛠️ Future Work

None

---

## ➕️ Additional Information

None

---

## 🧾 Release Note

PR title
