### PR TITLE
chore: bump numpy>=2.0

### DIFF
--- a/deltakit-explorer/pyproject.toml
+++ b/deltakit-explorer/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "deltakit-decode",
     "gql >=3.5.0",
     "graphql_core >=3.2.0",
-    "numpy >=1.26",
+    "numpy >=2.0",
     "stim >=1.9.0",
     "matplotlib >=3.5.2",
     "requests >=2.32.0",


### PR DESCRIPTION
## 🔗 Closed Issues

None, this is a small fix.

---

## 📝 Description

This PR bumps numpy minimum version to 2.0 in `deltakit_explorer`. This change is required because `numpy.unique_counts` is used in the code base, and was introduced in 2.0.

---

## 🚦 Status

Ready to be merged.

---

## 🛠️ Future Work

Use a better dependency management system (https://github.com/Deltakit/deltakit/issues/145) such that we can test both minimum and maximum allowed versions. Such a thing would have catched that bug before.

---

## ➕️ Additional Information

None

---

## 🧾 Release Note

PR title