### PR TITLE
ci: use ubuntu-slim runner when possible

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   check-deltakit-token:
     name: Check if Deltakit token exists
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       exists: ${{ steps.deltakit-token.outputs.exists }}
     steps:

--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   label-prs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,7 @@ jobs:
   # Because there is no easy way to ensure that label_pr.yml runs before this workflow,
   # this job returns all the packages when no tags are set.
   define-project-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       projects: ${{ steps.json_labels.outputs.projects }}
     steps:
@@ -33,7 +33,7 @@ jobs:
 
   # Build deltakit wheels.
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: define-project-matrix
     strategy:
       matrix:
@@ -56,7 +56,7 @@ jobs:
 
   merge_upload_artefacts:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Merge Artefacts
         uses: actions/upload-artifact/merge@v4


### PR DESCRIPTION
## 🔗 Closed Issues

Towards #19 by improving CI.

---

## 📝 Description

This PR replaces some of the runners in CI from `ubuntu-latest` to `ubuntu-slim`. 

Full documentation for `ubuntu-slim` runner: https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners. 

Summary is: `ubuntu-latest` uses 4 cores, `ubuntu-slim` only uses 1, for lightweight tasks `ubuntu-slim` should be favoured, `ubuntu-slim` is 3 times less expensive than `ubuntu-latest` when required to pay actions.

---

## 🚦 Status

Ready to merge.

---

## 🛠️ Future Work

Explore solutions to #19

---

## ➕️ Additional Information

None

---

## 🧾 Release Note

PR title