### PR TITLE
chore: better handling of stim version in deltakit_circuit

### DIFF
--- a/deltakit-circuit/src/deltakit_circuit/_stim_version_compatibility.py
+++ b/deltakit-circuit/src/deltakit_circuit/_stim_version_compatibility.py
@@ -1,17 +1,13 @@
-import warnings
 from importlib.metadata import PackageNotFoundError, version
 
 from packaging.version import Version
 
 
-def _get_stim_version() -> Version:
+def _get_stim_version() -> Version | None:
     try:
         return Version(version("stim"))
     except PackageNotFoundError:
-        warnings.warn(
-            "Could not get the current version of 'stim'. Assuming 0.0.1.", stacklevel=1
-        )
-        return Version("0.0.1")
+        return None
 
 
 _INSTALLED_STIM_VERSION = _get_stim_version()
@@ -19,4 +15,7 @@ _LOWEST_STIM_VERSION_WITH_TAG_FEATURE = Version("1.15")
 
 
 def is_stim_tag_feature_available() -> bool:
-    return _INSTALLED_STIM_VERSION >= _LOWEST_STIM_VERSION_WITH_TAG_FEATURE
+    return (
+        _INSTALLED_STIM_VERSION is not None
+        and _INSTALLED_STIM_VERSION >= _LOWEST_STIM_VERSION_WITH_TAG_FEATURE
+    )


### PR DESCRIPTION
## 🔗 Closed Issues

None, this is a small live fix.

---

## 📝 Description

This PR fixes a small inconsistency where we would return a fake version "0.0.1" for `stim` instead of returning `None` that better reflects the absence of version.

---

## 🚦 Status

Ready to merge

---

## 🛠️ Future Work

None

---

## ➕️ Additional Information

None

---

## 🧾 Release Note

PR title