### PR TITLE
Do not run coverage report when PR comes from fork

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,6 +33,8 @@ jobs:
     name: Test deltakit on ${{ matrix.python-version }} with ${{matrix.dependency-resolution}}
     env:
       ENABLE_COVERAGE: ${{ (matrix.python-version == '3.10') && (matrix.dependency-resolution == 'highest') }}
+      # See https://github.com/orgs/community/discussions/25217
+      PR_IS_NOT_FROM_FORK: ${{ github.event.pull_request.head.repo.full_name == 'deltakit/deltakit' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -58,7 +60,7 @@ jobs:
           uv run --no-sync coverage xml
           uv run --no-sync coverage report
       - name: Printing coverage report as a message
-        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        if: ${{ env.ENABLE_COVERAGE == 'true' && env.PR_IS_NOT_FROM_FORK}}
         uses: 5monkeys/cobertura-action@v13
         with:
           repo_token : ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🔗 Closed Issues

Closes #169

---

## 📝 Description

Avoid running the step named "Printing coverage report as a message" when the PR comes from a branch that is in a fork.

---

## 🚦 Status

Ready for review.

---

## 🛠️ Future Work

None

---

## ➕️ Additional Information

None

---

## 🧾 Release Note

PR title