### PR TITLE
Do not run coverage report when PR comes from fork

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -60,7 +60,7 @@ jobs:
           uv run --no-sync coverage xml
           uv run --no-sync coverage report
       - name: Printing coverage report as a message
-        if: ${{ env.ENABLE_COVERAGE == 'true' && env.PR_IS_FROM_FORK == 'false' }}
+        if: ${{ env.ENABLE_COVERAGE == 'true' && env.PR_FROM_FORK == 'false' }}
         uses: 5monkeys/cobertura-action@v13
         with:
           repo_token : ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🔗 Closed Issues

Closes #169

---

## 📝 Description

Avoid running the step named "Printing coverage report as a message" when the PR comes from a branch that is in a fork.

---

## 🚦 Status

Ready for review.

---

## 🛠️ Future Work

None

---

## ➕️ Additional Information

This PR is exactly the same as #170, but is open from my own fork to test the changes.

---

## 🧾 Release Note

PR title