### PR TITLE
fix: publishing to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,10 @@ jobs:
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
         python-version: ['3.10', '3.11', '3.12', '3.13']
         dependency-resolution: ['highest', 'lowest-direct']
+        exclude:
+          # No pre-built wheels for stim
+          - os: 'windows-latest'
+            python-version: '3.13'
     steps:
       - name: Checking out the deltakit repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## 🔗 Closed Issues

None, this fixes a release issue in CI encoutered while trying to release a new version of `deltakit`.

---

## 📝 Description

Fix a left-over typo in CI.

---

## 🚦 Status

Ready for merge.

---

## 🛠️ Future Work

Release `deltakit==0.6.0`.

---

## ➕️ Additional Information

None

---

## 🧾 Release Note

PR title