### PR TITLE
Release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- version list -->
 
+## v0.7.1 (2026-02-10)
+
+### Features
+
+- Fix dependencies of deltakit subpackages.
+
+
 ## v0.7.0 (2026-02-10)
 
 ### Features

--- a/deltakit-circuit/pyproject.toml
+++ b/deltakit-circuit/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "deltakit-circuit"
-version = "0.7.0"
+version = "0.7.1"
 description = "Deltakit (component deltakit-circuit)"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/deltakit-compile/pyproject.toml
+++ b/deltakit-compile/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "deltakit-compile"
-version = "0.7.0"
+version = "0.7.1"
 description = "Deltakit (component deltakit-compile)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/deltakit-core/pyproject.toml
+++ b/deltakit-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "deltakit-core"
-version = "0.7.0"
+version = "0.7.1"
 description = "Deltakit (component deltakit-core)"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/deltakit-decode/pyproject.toml
+++ b/deltakit-decode/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "deltakit-decode"
-version = "0.7.0"
+version = "0.7.1"
 description = "Deltakit (component deltakit-decode)"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
@@ -32,8 +32,8 @@ classifiers = [
 ]
 
 dependencies = [
-  "deltakit-circuit~=0.6",
-  "deltakit-core~=0.6",
+  "deltakit-circuit>=0.7.1",
+  "deltakit-core>=0.7.1",
   "numpy>=1.26",
   "networkx~=3.1",
   "seaborn~=0.12",

--- a/deltakit-explorer/pyproject.toml
+++ b/deltakit-explorer/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "deltakit-explorer"
-version = "0.7.0"
+version = "0.7.1"
 description = "Deltakit (component deltakit-explorer)"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
@@ -32,9 +32,9 @@ classifiers = [
 ]
 
 dependencies = [
-  "deltakit-core~=0.6",
-  "deltakit-circuit~=0.6",
-  "deltakit-decode~=0.6",
+  "deltakit-core>=0.7.1",
+  "deltakit-circuit>=0.7.1",
+  "deltakit-decode>=0.7",
   "gql[requests]~=3.5",
   "graphql_core~=3.2",
   "numpy~=2.0",

--- a/licenses.confluence
+++ b/licenses.confluence
@@ -42,11 +42,11 @@
 | debugpy                       | 1.8.19      | MIT License                                                                                      |
 | decorator                     | 5.2.1       | BSD License                                                                                      |
 | defusedxml                    | 0.7.1       | Python Software Foundation License                                                               |
-| deltakit                      | 0.6.2       | Apache-2.0                                                                                       |
-| deltakit-circuit              | 0.6.2       | Apache-2.0                                                                                       |
-| deltakit-core                 | 0.6.2       | Apache-2.0                                                                                       |
-| deltakit-decode               | 0.6.2       | Apache-2.0                                                                                       |
-| deltakit-explorer             | 0.6.2       | Apache-2.0                                                                                       |
+| deltakit                      | 0.7.1       | Apache-2.0                                                                                       |
+| deltakit-circuit              | 0.7.1       | Apache-2.0                                                                                       |
+| deltakit-core                 | 0.7.1       | Apache-2.0                                                                                       |
+| deltakit-decode               | 0.7.1       | Apache-2.0                                                                                       |
+| deltakit-explorer             | 0.7.1       | Apache-2.0                                                                                       |
 | deptry                        | 0.24.0      | MIT License                                                                                      |
 | dill                          | 0.4.0       | BSD License                                                                                      |
 | distlib                       | 0.4.0       | Python Software Foundation License                                                               |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "deltakit"
-version = "0.7.0"
+version = "0.7.1"
 description = "A Python toolkit to enable users with the design and execution of quantum error correction (QEC) experiments."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
@@ -32,10 +32,10 @@ classifiers = [
 ]
 
 dependencies = [
-  "deltakit-circuit~=0.6",
-  "deltakit-core~=0.6",
-  "deltakit-decode~=0.6",
-  "deltakit-explorer~=0.6",
+  "deltakit-circuit>=0.7.1",
+  "deltakit-core>=0.7.1",
+  "deltakit-decode>=0.7.1",
+  "deltakit-explorer>=0.7.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR releases version `0.7.1`. Version `0.7.0` had incorrect dependencies, and will be yanked.