### PR TITLE
refactor(explorer): consolidate surface-code patch plotting

### DIFF
--- a/deltakit-explorer/src/deltakit_explorer/codes/_planar_code/_planar_code.py
+++ b/deltakit-explorer/src/deltakit_explorer/codes/_planar_code/_planar_code.py
@@ -3,14 +3,11 @@
 This module contains common implementation parts for planar codes.
 Other planar code classes derive from PlanarCode.
 """
-import itertools
 import warnings
 from abc import ABC, abstractmethod
 from enum import Enum
 from functools import cached_property
-from pathlib import Path
 
-import matplotlib.pyplot as plt
 import numpy as np
 from deltakit_circuit import PauliX, PauliZ, Qubit
 from deltakit_circuit._basic_types import Coord2D, Coord2DDelta
@@ -18,7 +15,7 @@ from deltakit_circuit._qubit_identifiers import PauliGate
 
 from deltakit_explorer.codes._css._css_code import CSSCode
 from deltakit_explorer.codes._stabiliser import Stabiliser
-from deltakit_explorer.enums._basic_enums import DrawingColours
+from deltakit_explorer.plotting._surface_code_patch import draw_surface_code_patch
 
 
 class ScheduleType(Enum):
@@ -411,117 +408,18 @@ class PlanarCode(CSSCode, ABC):
             Path to the file where to save the pictorial representation of the
             planar code stored in this class.
         """
-        all_qubit_x_coords = [qubit.unique_identifier.x for qubit in self.qubits]
-        all_qubit_y_coords = [qubit.unique_identifier.y for qubit in self.qubits]
         diff_from_max_coord_to_margin_no_ancilla = (
             2 if not unrotated_code or not (self.linear_tr == np.eye(2)).all() else 1
         )
-        if self._use_ancilla_qubits:
-            min_x, max_x = min(all_qubit_x_coords) - 1, max(all_qubit_x_coords) + 1
-            min_y, max_y = min(all_qubit_y_coords) - 1, max(all_qubit_y_coords) + 1
-        else:
-            min_x, max_x = (
-                min(all_qubit_x_coords) - diff_from_max_coord_to_margin_no_ancilla,
-                max(all_qubit_x_coords) + diff_from_max_coord_to_margin_no_ancilla,
-            )
-            min_y, max_y = (
-                min(all_qubit_y_coords) - diff_from_max_coord_to_margin_no_ancilla,
-                max(all_qubit_y_coords) + diff_from_max_coord_to_margin_no_ancilla,
-            )
-        x_lim = (min_x, max_x)
-        y_lim = (min_y, max_y)
-        fig, ax = plt.subplots(nrows=1, ncols=1)
-        ax.set_xlim(x_lim)
-        ax.set_ylim(y_lim)
-
-        stabilisers = tuple(itertools.chain.from_iterable(self._stabilisers))
-        stabilisers = self._sort_stabilisers(stabilisers)
-
-        # Draw stabiliser plaquettes
-        for stabiliser in stabilisers:
-            data_qubit_x_coords = [
-                pauli.qubit.unique_identifier[0]
-                for pauli in stabiliser.paulis
-                if pauli is not None
-            ]
-            data_qubit_y_coords = [
-                pauli.qubit.unique_identifier[1]
-                for pauli in stabiliser.paulis
-                if pauli is not None
-            ]
-
-            paulis = [pauli for pauli in stabiliser.paulis if pauli is not None]
-
-            if len(paulis) == 2:
-                ancilla_coord = stabiliser.ancilla_qubit.unique_identifier
-                data_qubit_x_coords.append(ancilla_coord[0])
-                data_qubit_y_coords.append(ancilla_coord[1])
-            elif len(paulis) == 4:
-                data_qubit_x_coords[2], data_qubit_x_coords[3] = (
-                    data_qubit_x_coords[3],
-                    data_qubit_x_coords[2],
-                )
-                data_qubit_y_coords[2], data_qubit_y_coords[3] = (
-                    data_qubit_y_coords[3],
-                    data_qubit_y_coords[2],
-                )
-
-            if isinstance(paulis[0], PauliX):
-                ax.fill(
-                    data_qubit_x_coords,
-                    data_qubit_y_coords,
-                    color=DrawingColours.X_COLOUR.value,
-                    alpha=1,
-                )
-            else:
-                ax.fill(
-                    data_qubit_x_coords,
-                    data_qubit_y_coords,
-                    color=DrawingColours.Z_COLOUR.value,
-                    alpha=1,
-                )
-
-        # Draw data qubits
-        for qubit in self._data_qubits:
-            cc = plt.Circle(
-                qubit.unique_identifier,
-                0.2,
-                color=DrawingColours.DATA_QUBIT_COLOUR.value,
-                alpha=1,
-            )
-            ax.set_aspect(1)
-            ax.add_artist(cc)
-
-        if self._use_ancilla_qubits:
-            # Draw X stabiliser ancilla qubits
-            for qubit in self._x_ancilla_qubits:
-                cc = plt.Circle(
-                    qubit.unique_identifier,
-                    0.2,
-                    color=DrawingColours.ANCILLA_QUBIT_COLOUR.value,
-                    alpha=1,
-                )
-                ax.set_aspect(1)
-                ax.add_artist(cc)
-
-            # Draw Z stabiliser ancilla qubits
-            for qubit in self._z_ancilla_qubits:
-                cc = plt.Circle(
-                    qubit.unique_identifier,
-                    0.2,
-                    color=DrawingColours.ANCILLA_QUBIT_COLOUR.value,
-                    alpha=1,
-                )
-                ax.set_aspect(1)
-                ax.add_artist(cc)
-
-        # Save the file
-        if filename:
-            output_directory = Path(filename)
-            if not output_directory.exists():
-                output_directory.parent.mkdir(parents=True, exist_ok=True)
-            fig.savefig(filename)
-            plt.close(fig)
+        margin = (
+            1 if self._use_ancilla_qubits else diff_from_max_coord_to_margin_no_ancilla
+        )
+        draw_surface_code_patch(
+            self,
+            filename=filename,
+            margin=margin,
+            sort_stabilisers=True,
+        )
 
     @cached_property
     def x0(self) -> int:

--- a/deltakit-explorer/src/deltakit_explorer/codes/_planar_code/_unrotated_toric_code.py
+++ b/deltakit-explorer/src/deltakit_explorer/codes/_planar_code/_unrotated_toric_code.py
@@ -5,16 +5,10 @@ represents two logical qubits.
 """
 
 import itertools
-from pathlib import Path
 
-import matplotlib.pyplot as plt
-import numpy.typing as npt
 from deltakit_circuit import PauliX, PauliZ, Qubit
 from deltakit_circuit._basic_types import Coord2D, Coord2DDelta
 from deltakit_circuit._qubit_identifiers import PauliGate
-from matplotlib.lines import Line2D
-from matplotlib.patches import Patch
-from numpy import arctan2, argsort, array, int8
 
 from deltakit_explorer.codes._planar_code._planar_code import PlanarCode, ScheduleType
 from deltakit_explorer.codes._schedules._schedule_order import (
@@ -25,7 +19,7 @@ from deltakit_explorer.codes._schedules._unrotated_planar_code_schedules import 
     UnrotatedPlanarCodeSchedules,
 )
 from deltakit_explorer.codes._stabiliser import Stabiliser
-from deltakit_explorer.enums._basic_enums import DrawingColours
+from deltakit_explorer.plotting._surface_code_patch import draw_surface_code_patch
 
 
 class UnrotatedToricCode(PlanarCode):
@@ -164,152 +158,11 @@ class UnrotatedToricCode(PlanarCode):
         return (x_logicals, z_logicals)
 
     def draw_patch(self, filename: str | None = None, unrotated_code: bool = False) -> None:  # noqa: ARG002
-        fig, ax = plt.subplots(nrows=1, ncols=1)
-        all_qubit_x_coords = [qubit.unique_identifier.x for qubit in self.qubits]
-        all_qubit_y_coords = [qubit.unique_identifier.y for qubit in self.qubits]
-        min_x, max_x = min(all_qubit_x_coords) - 2, max(all_qubit_x_coords) + 2
-        min_y, max_y = min(all_qubit_y_coords) - 2, max(all_qubit_y_coords) + 2
-        ax.set_xlim((min_x, max_x))
-        ax.set_ylim((min_y, max_y))
-
-        stabilisers: tuple[Stabiliser, ...] = tuple(
-            itertools.chain.from_iterable(self._stabilisers)
+        draw_surface_code_patch(
+            self,
+            filename=filename,
+            margin=2,
+            show_legend=True,
+            periodic=(2 * self.width, 2 * self.height),
+            order_vertices_by_angle=True,
         )
-
-        # Draw stabiliser plaquettes
-        for stabiliser in stabilisers:
-            data_qubit_x_coords = [
-                pauli.qubit.unique_identifier[0]
-                for pauli in stabiliser.paulis
-                if pauli is not None
-            ]
-
-            data_qubit_y_coords = [
-                pauli.qubit.unique_identifier[1]
-                for pauli in stabiliser.paulis
-                if pauli is not None
-            ]
-
-            # Wrap boundary stabilisers on the X axis
-            if 0 in data_qubit_x_coords and 2 * self.width - 1 in data_qubit_x_coords:
-                if data_qubit_x_coords.count(0) > data_qubit_x_coords.count(
-                    2 * self.width - 1
-                ):
-                    data_qubit_x_coords = [
-                        -1 if x == 2 * self.width - 1 else x
-                        for x in data_qubit_x_coords
-                    ]
-                else:
-                    data_qubit_x_coords = [
-                        2 * self.width if x == 0 else x for x in data_qubit_x_coords
-                    ]
-
-            # Wrap boundary stabilisers on the Y axis
-            if 0 in data_qubit_y_coords and 2 * self.height - 1 in data_qubit_y_coords:
-                if data_qubit_y_coords.count(0) > data_qubit_y_coords.count(
-                    2 * self.height - 1
-                ):
-                    data_qubit_y_coords = [
-                        -1 if y == 2 * self.height - 1 else y
-                        for y in data_qubit_y_coords
-                    ]
-                else:
-                    data_qubit_y_coords = [
-                        2 * self.height if y == 0 else y for y in data_qubit_y_coords
-                    ]
-
-            # Re order data qubit coords for polygon drawing
-            ordered_data_qubit_y_coords: npt.NDArray[int8] = array(data_qubit_y_coords)
-            ordered_data_qubit_x_coords: npt.NDArray[int8] = array(data_qubit_x_coords)
-
-            order = argsort(
-                arctan2(
-                    ordered_data_qubit_y_coords - ordered_data_qubit_y_coords.mean(),
-                    ordered_data_qubit_x_coords - ordered_data_qubit_x_coords.mean(),
-                )
-            )
-
-            paulis = [pauli for pauli in stabiliser.paulis if pauli is not None]
-            ax.fill(
-                ordered_data_qubit_x_coords[order],
-                ordered_data_qubit_y_coords[order],
-                color=(
-                    DrawingColours.X_COLOUR.value
-                    if isinstance(paulis[0], PauliX)
-                    else DrawingColours.Z_COLOUR.value
-                ),
-                alpha=1,
-            )
-
-        # Draw data qubits
-        for qubit in self._data_qubits:
-            cc = plt.Circle(
-                qubit.unique_identifier,
-                0.2,
-                color=DrawingColours.DATA_QUBIT_COLOUR.value,
-                alpha=1,
-            )
-            ax.set_aspect(1)
-            ax.add_artist(cc)
-
-        # Draw stabiliser ancilla qubits
-        if self._use_ancilla_qubits:
-            # Draw X stabiliser ancilla qubits
-            for qubit in self._x_ancilla_qubits:
-                cc = plt.Circle(
-                    qubit.unique_identifier,
-                    0.2,
-                    color=DrawingColours.ANCILLA_QUBIT_COLOUR.value,
-                    alpha=1,
-                )
-                ax.set_aspect(1)
-                ax.add_artist(cc)
-
-            # Draw X stabiliser ancilla qubits
-            for qubit in self._z_ancilla_qubits:
-                cc = plt.Circle(
-                    qubit.unique_identifier,
-                    0.2,
-                    color=DrawingColours.ANCILLA_QUBIT_COLOUR.value,
-                    alpha=1,
-                )
-                ax.set_aspect(1)
-                ax.add_artist(cc)
-
-        # Create a legend
-        legend_elements = [
-            Line2D(
-                [0],
-                [0],
-                marker="o",
-                color="w",
-                label="Data Qubit",
-                markerfacecolor=DrawingColours.DATA_QUBIT_COLOUR.value,
-                markersize=15,
-            ),
-            Line2D(
-                [0],
-                [0],
-                marker="o",
-                color="w",
-                label="Ancilla Qubit",
-                markerfacecolor=DrawingColours.ANCILLA_QUBIT_COLOUR.value,
-                markersize=15,
-            ),
-            Patch(facecolor=DrawingColours.X_COLOUR.value, label="X Stabiliser"),
-            Patch(facecolor=DrawingColours.Z_COLOUR.value, label="Z Stabiliser"),
-        ]
-        legend = ax.legend(
-            handles=legend_elements,
-            loc="upper center",
-            bbox_to_anchor=(0.5, -0.1),
-            ncol=2,
-        )
-
-        if filename is not None:
-            # Save the file
-            output_directory = Path(filename)
-            if not output_directory.exists():
-                output_directory.parent.mkdir(parents=True, exist_ok=True)
-            fig.savefig(filename, bbox_extra_artists=(legend,), bbox_inches="tight")
-            plt.close(fig)

--- a/deltakit-explorer/src/deltakit_explorer/plotting/__init__.py
+++ b/deltakit-explorer/src/deltakit_explorer/plotting/__init__.py
@@ -3,6 +3,7 @@
 
 from deltakit_explorer.plotting._lambda import plot_lambda
 from deltakit_explorer.plotting._leppr import plot_logical_error_probability_per_round
+from deltakit_explorer.plotting._surface_code_patch import draw_surface_code_patch
 from deltakit_explorer.plotting._visualisation import (
                                                             correlation_matrix,
                                                             defect_diagram,

--- a/deltakit-explorer/src/deltakit_explorer/plotting/_surface_code_patch.py
+++ b/deltakit-explorer/src/deltakit_explorer/plotting/_surface_code_patch.py
@@ -1,0 +1,245 @@
+# (c) Copyright Riverlane 2020-2025.
+"""Helpers for drawing surface-code style patches."""
+
+from __future__ import annotations
+
+import itertools
+import math
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+from deltakit_circuit import PauliX
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from matplotlib.lines import Line2D
+from matplotlib.patches import Patch
+
+from deltakit_explorer.codes._stabiliser import Stabiliser
+from deltakit_explorer.enums._basic_enums import DrawingColours
+
+
+def _count_nones_at_the_end(stabiliser: Stabiliser) -> int:
+    """Count trailing ``None`` values in a stabiliser's Pauli list.
+
+    Args:
+        stabiliser: Stabiliser to inspect.
+
+    Returns:
+        Number of consecutive ``None`` values at the end of ``stabiliser.paulis``.
+    """
+    counter = 0
+    for pauli in stabiliser.paulis[::-1]:
+        if pauli is None:
+            counter += 1
+        else:
+            break
+    return counter
+
+
+def _contains_x(stabiliser: Stabiliser) -> int:
+    """Return whether a stabiliser contains any ``PauliX`` operators.
+
+    Args:
+        stabiliser: Stabiliser to inspect.
+
+    Returns:
+        ``1`` if at least one non-``None`` Pauli is ``PauliX``, otherwise ``0``.
+    """
+    for pauli in stabiliser.paulis:
+        if isinstance(pauli, PauliX):
+            return 1
+    return 0
+
+
+def _sort_stabilisers(stabilisers: tuple[Stabiliser, ...]) -> tuple[Stabiliser, ...]:
+    """Sort stabilisers matching legacy planar ordering semantics.
+
+    Args:
+        stabilisers: Stabilisers to sort.
+
+    Returns:
+        Stabilisers sorted by trailing ``None`` count (descending), then by
+        whether they contain a ``PauliX`` (descending).
+    """
+    return tuple(
+        sorted(
+            sorted(stabilisers, key=_contains_x, reverse=True),
+            key=_count_nones_at_the_end,
+            reverse=True,
+        )
+    )
+
+
+def _wrap_periodic_axis(coords: list[int], period: int) -> list[int]:
+    """Wrap coordinates across a periodic boundary for plotting.
+
+    Args:
+        coords: Axis coordinates for a single plaquette polygon.
+        period: Axis period.
+
+    Returns:
+        Coordinates adjusted to avoid plotting across the full periodic span.
+    """
+    upper = period - 1
+    if 0 in coords and upper in coords:
+        if coords.count(0) > coords.count(upper):
+            return [-1 if coord == upper else coord for coord in coords]
+        return [period if coord == 0 else coord for coord in coords]
+    return coords
+
+
+def _order_vertices_by_angle(
+    x_coords: list[int], y_coords: list[int]
+) -> tuple[list[int], list[int]]:
+    """Order polygon vertices by angle around their centroid.
+
+    Args:
+        x_coords: Polygon x-coordinates.
+        y_coords: Polygon y-coordinates.
+
+    Returns:
+        Reordered x- and y-coordinate lists.
+    """
+    x_mean = sum(x_coords) / len(x_coords)
+    y_mean = sum(y_coords) / len(y_coords)
+    order = sorted(
+        range(len(x_coords)),
+        key=lambda index: math.atan2(y_coords[index] - y_mean, x_coords[index] - x_mean),
+    )
+    return [x_coords[index] for index in order], [y_coords[index] for index in order]
+
+
+def draw_surface_code_patch(
+    code,
+    filename: str | None = None,
+    margin: int = 2,
+    show_legend: bool = False,
+    sort_stabilisers: bool = False,
+    periodic: tuple[int, int] | None = None,
+    order_vertices_by_angle: bool = False,
+) -> tuple[Figure, Axes]:
+    """Draw a surface-code style patch.
+
+    Args:
+        code: Code object exposing ``qubits``, ``stabilisers``, ``data_qubits``,
+            ``ancilla_qubits`` and ``use_ancilla_qubits`` attributes.
+        filename: Optional output path. If provided, the figure is saved and closed.
+        margin: Margin to apply around the qubit-coordinate bounding box.
+        show_legend: Whether to add the toric-style legend.
+        sort_stabilisers: Whether to sort stabilisers with legacy planar ordering.
+        periodic: Optional ``(period_x, period_y)`` for toric boundary wrapping.
+        order_vertices_by_angle: Whether to reorder each plaquette polygon by angle
+            around its centroid.
+
+    Returns:
+        ``(fig, ax)`` containing the resulting patch drawing.
+    """
+    fig, ax = plt.subplots(nrows=1, ncols=1)
+
+    all_qubit_x_coords = [qubit.unique_identifier.x for qubit in code.qubits]
+    all_qubit_y_coords = [qubit.unique_identifier.y for qubit in code.qubits]
+    ax.set_xlim(min(all_qubit_x_coords) - margin, max(all_qubit_x_coords) + margin)
+    ax.set_ylim(min(all_qubit_y_coords) - margin, max(all_qubit_y_coords) + margin)
+
+    stabilisers: tuple[Stabiliser, ...] = tuple(
+        itertools.chain.from_iterable(code.stabilisers)
+    )
+    if sort_stabilisers:
+        stabilisers = _sort_stabilisers(stabilisers)
+
+    for stabiliser in stabilisers:
+        paulis = [pauli for pauli in stabiliser.paulis if pauli is not None]
+        x_coords = [pauli.qubit.unique_identifier[0] for pauli in paulis]
+        y_coords = [pauli.qubit.unique_identifier[1] for pauli in paulis]
+
+        if len(paulis) == 2 and stabiliser.ancilla_qubit is not None:
+            ancilla_coords = stabiliser.ancilla_qubit.unique_identifier
+            x_coords.append(ancilla_coords[0])
+            y_coords.append(ancilla_coords[1])
+
+        if periodic is not None:
+            period_x, period_y = periodic
+            x_coords = _wrap_periodic_axis(x_coords, period_x)
+            y_coords = _wrap_periodic_axis(y_coords, period_y)
+
+        if order_vertices_by_angle:
+            x_coords, y_coords = _order_vertices_by_angle(x_coords, y_coords)
+        elif len(paulis) == 4:
+            x_coords[2], x_coords[3] = x_coords[3], x_coords[2]
+            y_coords[2], y_coords[3] = y_coords[3], y_coords[2]
+
+        ax.fill(
+            x_coords,
+            y_coords,
+            color=(
+                DrawingColours.X_COLOUR.value
+                if isinstance(paulis[0], PauliX)
+                else DrawingColours.Z_COLOUR.value
+            ),
+            alpha=1,
+        )
+
+    for qubit in code.data_qubits:
+        ax.add_artist(
+            plt.Circle(
+                qubit.unique_identifier,
+                0.2,
+                color=DrawingColours.DATA_QUBIT_COLOUR.value,
+                alpha=1,
+            )
+        )
+
+    if code.use_ancilla_qubits:
+        for qubit in code.ancilla_qubits:
+            ax.add_artist(
+                plt.Circle(
+                    qubit.unique_identifier,
+                    0.2,
+                    color=DrawingColours.ANCILLA_QUBIT_COLOUR.value,
+                    alpha=1,
+                )
+            )
+
+    ax.set_aspect(1)
+
+    legend = None
+    if show_legend:
+        legend_elements = [
+            Line2D(
+                [0],
+                [0],
+                marker="o",
+                color="w",
+                label="Data Qubit",
+                markerfacecolor=DrawingColours.DATA_QUBIT_COLOUR.value,
+                markersize=15,
+            ),
+            Line2D(
+                [0],
+                [0],
+                marker="o",
+                color="w",
+                label="Ancilla Qubit",
+                markerfacecolor=DrawingColours.ANCILLA_QUBIT_COLOUR.value,
+                markersize=15,
+            ),
+            Patch(facecolor=DrawingColours.X_COLOUR.value, label="X Stabiliser"),
+            Patch(facecolor=DrawingColours.Z_COLOUR.value, label="Z Stabiliser"),
+        ]
+        legend = ax.legend(
+            handles=legend_elements,
+            loc="upper center",
+            bbox_to_anchor=(0.5, -0.1),
+            ncol=2,
+        )
+
+    if filename is not None:
+        output_path = Path(filename)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        if legend is not None:
+            fig.savefig(filename, bbox_extra_artists=(legend,), bbox_inches="tight")
+        else:
+            fig.savefig(filename)
+        plt.close(fig)
+
+    return fig, ax

--- a/deltakit-explorer/tests/plotting/test_surface_code_patch.py
+++ b/deltakit-explorer/tests/plotting/test_surface_code_patch.py
@@ -1,0 +1,47 @@
+# (c) Copyright Riverlane 2020-2025.
+
+import matplotlib.pyplot as plt
+from matplotlib.patches import Circle, Polygon
+
+from deltakit_explorer.codes._planar_code import RotatedPlanarCode, UnrotatedToricCode
+from deltakit_explorer.plotting._surface_code_patch import draw_surface_code_patch
+
+
+def test_planar_draw_patch_saves_png(tmp_path):
+    code = RotatedPlanarCode(width=2, height=2, use_ancilla_qubits=True)
+    out = tmp_path / "planar.png"
+    code.draw_patch(str(out))
+    assert out.exists()
+    assert out.stat().st_size > 0
+
+
+def test_toric_draw_patch_saves_png(tmp_path):
+    code = UnrotatedToricCode(
+        horizontal_distance=2,
+        vertical_distance=2,
+        use_ancilla_qubits=True,
+    )
+    out = tmp_path / "toric.png"
+    code.draw_patch(str(out))
+    assert out.exists()
+    assert out.stat().st_size > 0
+
+
+def test_draw_surface_code_patch_artist_counts():
+    code = RotatedPlanarCode(width=3, height=3, use_ancilla_qubits=True)
+    fig, ax = draw_surface_code_patch(code, margin=1, sort_stabilisers=True)
+
+    circles = [
+        artist
+        for artist in ax.get_children()
+        if isinstance(artist, Circle)
+    ]
+    polys = [
+        artist
+        for artist in ax.get_children()
+        if isinstance(artist, Polygon)
+    ]
+
+    assert len(circles) == len(code.data_qubits) + len(code.ancilla_qubits)
+    assert len(polys) == sum(len(layer) for layer in code.stabilisers)
+    plt.close(fig)


### PR DESCRIPTION
  Closes #72

  ## Description

  Refactors duplicated surface-code patch plotting logic into a shared helper and updates code classes to delegate to
  it.

  Changes:

  - Added draw_surface_code_patch(...) in deltakit-explorer/src/deltakit_explorer/plotting/_surface_code_patch.py.
  - Re-exported helper from deltakit-explorer/src/deltakit_explorer/plotting/__init__.py.
  - Updated PlanarCode.draw_patch to call shared helper while preserving legacy margin logic.
  - Updated UnrotatedToricCode.draw_patch to call shared helper with toric-specific legend, periodic wrapping, and
    angle-based vertex ordering.
  - Added tests in deltakit-explorer/tests/plotting/test_surface_code_patch.py:
      - planar patch save
      - toric patch save
      - helper artist counts (circles/polygons)

  Behavior parity preserved for colors, legend behavior, polygon ordering, boundary wrapping, and save/close behavior.

  ## Status

  Ready for review.

  ## Future Work

  None required for this issue.

  ## Additional Information

  This PR is intentionally minimal and only touches plotting consolidation + related tests.

  ## Release Note

  refactor(explorer): consolidate surface-code patch plotting