### PR TITLE
refactor: deprecate `plot_correlation_matrix` and consolidate with `correlation_matrix`

### DIFF
--- a/deltakit-decode/src/deltakit_decode/utils/_pij_visualiser.py
+++ b/deltakit-decode/src/deltakit_decode/utils/_pij_visualiser.py
@@ -1,11 +1,16 @@
 # (c) Copyright Riverlane 2020-2025.
 from collections.abc import Sequence
 
-import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.ticker import FuncFormatter
+from deltakit_core.deprecation import deprecated
+from deltakit_explorer.plotting import correlation_matrix
+from deltakit_explorer.types._types import QubitCoordinateToDetectorMapping
 
 
+@deprecated(
+    reason="This function has been superseded by explorer plotting utilities.",
+    replaced_by="deltakit_explorer.plotting.correlation_matrix",
+)
 def plot_correlation_matrix(
     matrix: list[list[float]],
     major_minor_mapping: dict[tuple[float, ...], list[int]],
@@ -29,42 +34,8 @@ def plot_correlation_matrix(
     matplotlib.plt
         The plt object containing the drawn heatmap.
     """
-    try:
-        import seaborn as sns  # noqa: PLC0415
-    except ImportError as ie:
-        msg = "Seaborn is not installed - please install Visualisation extras"
-        raise ImportError(msg) from ie
-
-    # create a list of indices of the minor ticks for which to label with
-    # the qubit labels such that the labels are in the middle of the major
-    # ticks. Sort the labels as they are not guaranteed to be in order.
-    minor_ticks_in_major = len(next(iter(major_minor_mapping.values())))
-    num_major_ticks = len(major_minor_mapping.keys())
-    num_ticks = minor_ticks_in_major * num_major_ticks
-    num_minor_ticks = num_ticks - num_major_ticks
-    im = num_minor_ticks // num_major_ticks
-    mid_im = im // 2
-    label_indices = [mid_im + (im * i) for i in range(num_major_ticks)]
-    sorted_labels = sorted(major_minor_mapping.keys()) if len(labels) == 0 else labels
-
-    def format_func(_, tick_number):
-        if tick_number in label_indices:
-            return sorted_labels[label_indices.index(tick_number)]
-        return None
-
-    col1 = sns.cubehelix_palette(start=.2, rot=-.3, light=1.0, as_cmap=True)
-    ax = sns.heatmap(matrix, cmap=col1)
-    ax.invert_yaxis()
-    ax.set(xlabel="Qubits", ylabel="Qubits")
-    major_ticks = np.arange(0, len(matrix[0]), minor_ticks_in_major)
-    minor_ticks = np.arange(0, len(matrix[0]), 1)
-    ax.set_xticks(major_ticks)
-    ax.set_xticks(minor_ticks, minor=True)
-    ax.set_yticks(major_ticks)
-    ax.set_yticks(minor_ticks, minor=True)
-    ax.xaxis.set_minor_formatter(FuncFormatter(format_func))
-    ax.yaxis.set_minor_formatter(FuncFormatter(format_func))
-    ax.tick_params(axis="x", rotation=0)
-    ax.grid(which="major", color="#333333", linestyle="-", alpha=0.6)
-    ax.grid(which="minor", color="#AAAAAA", linestyle="--", alpha=0.2)
-    return plt
+    return correlation_matrix(
+        matrix=np.asarray(matrix),
+        qubit_to_detector_mapping=QubitCoordinateToDetectorMapping(major_minor_mapping),
+        labels=labels,
+    )

--- a/deltakit-decode/tests/unit/utils/test_pij_visualiser.py
+++ b/deltakit-decode/tests/unit/utils/test_pij_visualiser.py
@@ -2,7 +2,9 @@
 import platform
 from unittest import mock
 
+import numpy as np
 import pytest
+from deltakit_explorer.types._types import QubitCoordinateToDetectorMapping
 
 from deltakit_decode.utils._pij_visualiser import plot_correlation_matrix
 
@@ -36,14 +38,29 @@ class TestPijVisualiser:
                                "default TKinter backend needs a display")
     def test_plot_correlation_matrix_creates_figure(self, tmp_path, matrix, major_minor_mapping):
         filepath = tmp_path / "testfig.png"
-        plt = plot_correlation_matrix(matrix, major_minor_mapping)
+        with pytest.warns(DeprecationWarning, match=r"plot_correlation_matrix is deprecated"):
+            plt = plot_correlation_matrix(matrix, major_minor_mapping)
         plt.savefig(filepath)
         plt.clf()
         assert filepath.is_file()
 
-    def test_plot_correlation_matrix_raises_exception_if_seaborn_not_installed(self):
-        with (
-             mock.patch("builtins.__import__", side_effect=ImportError),
-             pytest.raises(ImportError, match=r"Seaborn is not installed - please install Visualisation extras")
-        ):
-            plot_correlation_matrix([], {})
+    def test_plot_correlation_matrix_uses_explorer_correlation_matrix(self):
+        matrix = [[1.0, 0.0], [0.0, 1.0]]
+        mapping = {(1.0, 4.0): [0], (3.0, 4.0): [1]}
+        labels = ("q0", "q1")
+
+        with mock.patch("deltakit_decode.utils._pij_visualiser.correlation_matrix", autospec=True) as mocked_correlation_matrix:
+            mocked_correlation_matrix.return_value = "plot_object"
+            with pytest.warns(DeprecationWarning, match=r"plot_correlation_matrix is deprecated"):
+                result = plot_correlation_matrix(matrix, mapping, labels=labels)
+
+        assert result == "plot_object"
+        mocked_correlation_matrix.assert_called_once()
+        called_matrix = mocked_correlation_matrix.call_args.kwargs["matrix"]
+        called_mapping = mocked_correlation_matrix.call_args.kwargs["qubit_to_detector_mapping"]
+        called_labels = mocked_correlation_matrix.call_args.kwargs["labels"]
+        assert isinstance(called_matrix, np.ndarray)
+        assert np.array_equal(called_matrix, np.asarray(matrix))
+        assert isinstance(called_mapping, QubitCoordinateToDetectorMapping)
+        assert called_mapping.detector_map == mapping
+        assert called_labels == labels

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -416,6 +416,10 @@ Description of ``deltakit.decode.noise_sources`` namespace here.
     split_measurement_bitstring
     VisDecodingGraph3D
 
+.. note::
+    ``plot_correlation_matrix`` is deprecated. Use
+    ``deltakit.explorer.plotting.correlation_matrix`` instead.
+
 .. _api-deltakit-explorer:
 
 ``deltakit.explorer``


### PR DESCRIPTION
## 🔗 Closed Issues
Closes #71

---

## 📝 Description
PR deprecates `deltakit_decode.utils._pij_visualiser.plot_correlation_matrix` and consolidates w/ `deltakit_explorer.plotting.correlation_matrix` 

### Changes
- Added deprecation via shared decorator:
  - `deltakit-decode/src/deltakit_decode/utils/_pij_visualiser.py`
  - `@deprecated(..., replaced_by="deltakit_explorer.plotting.correlation_matrix")`
- Refactored `plot_correlation_matrix` into a compatibility adapter that delegates to explorer:
  - converts `matrix` to `np.asarray(matrix)`
  - converts `major_minor_mapping` to `QubitCoordinateToDetectorMapping`
  - passes through `labels`
- Updated decode unit tests to reflect deprecation + delegation behavior:
  - `deltakit-decode/tests/unit/utils/test_pij_visualiser.py`
- Added API documentation note for migration:
  - `docs/api.rst`

---

## Status
- ✅ Consolidation complete: decode function now delegates to explorer implementation.
- ✅ Deprecation added using shared decorator.
- ✅ Targeted tests pass for decode + explorer correlation matrix behavior.
- ✅ Docs updated with migration note.

---

## 🛠️ Future Work
- Perhaps remove `plot_correlation_matrix` in a future major/minor version.
- Expand migration examples in docs to show side-by-side old/new call signatures.

---

## ➕️ Additional Information
Validation commands used:

```sh
uv run --group lint ruff check deltakit-decode/src/deltakit_decode/utils/_pij_visualiser.py deltakit-decode/tests/unit/utils/test_pij_visualiser.py --fix
uv run --group test pytest deltakit-decode/tests/unit/utils/test_pij_visualiser.py deltakit-explorer/tests/plotting/test_plotting.py::TestVisualisation::test_plot_correlation_matrix -q
```

Outcome: `5 passed`.

---

## 🧾 Release Note
`refactor: deprecate plot_correlation_matrix and consolidate with explorer correlation_matrix`
