### PR TITLE
feat: Rename class to avoid name ambiguity.

### DIFF
--- a/deltakit-explorer/src/deltakit_explorer/analysis/_lambda.py
+++ b/deltakit-explorer/src/deltakit_explorer/analysis/_lambda.py
@@ -11,7 +11,7 @@ import scipy.optimize
 
 
 @dataclass(frozen=True)
-class LambdaResults:
+class LambdaData:
     """Named-tuple-like class containing computation results from
     :func:`calculate_lambda_and_lambda_stddev`.
 
@@ -35,7 +35,7 @@ _LambdaFittingCallable = Callable[
         npt.NDArray[np.float64] | Sequence[float],
         npt.NDArray[np.float64] | Sequence[float],
     ],
-    LambdaResults,
+    LambdaData,
 ]
 
 
@@ -43,7 +43,7 @@ def _lambda_fit_with_d(
     distances: npt.NDArray[np.int_] | Sequence[int],
     lep_per_round: npt.NDArray[np.float64] | Sequence[float],
     lep_stddev_per_round: npt.NDArray[np.float64] | Sequence[float],
-) -> LambdaResults:
+) -> LambdaData:
     """Compute Λ, Λ_0 and their associated standard deviations by fitting the logarithm
     of ``lep_per_round`` with ``distance``.
     """
@@ -86,14 +86,14 @@ def _lambda_fit_with_d(
             - 2 * cov[0, 1]
         )
     )
-    return LambdaResults(lambda_value, lambda_value_stddev, lambda0, lambda0_stddev)
+    return LambdaData(lambda_value, lambda_value_stddev, lambda0, lambda0_stddev)
 
 
 def _lambda_fit_with_d_plus_1_over_2(
     distances: npt.NDArray[np.int_] | Sequence[int],
     lep_per_round: npt.NDArray[np.float64] | Sequence[float],
     lep_stddev_per_round: npt.NDArray[np.float64] | Sequence[float],
-) -> LambdaResults:
+) -> LambdaData:
     """Compute Λ, Λ_0 and their associated standard deviations by fitting the logarithm
     of ``lep_per_round`` with ``(distance + 1) / 2``.
     """
@@ -122,14 +122,14 @@ def _lambda_fit_with_d_plus_1_over_2(
     lambda_value_stddev = float(lambda_value * slope_stddev)
     lambda0 = float(np.exp(-offset))
     lambda0_stddev = float(lambda0 * offset_stddev)
-    return LambdaResults(lambda_value, lambda_value_stddev, lambda0, lambda0_stddev)
+    return LambdaData(lambda_value, lambda_value_stddev, lambda0, lambda0_stddev)
 
 
 def _lambda_fit_with_direct(
     distances: npt.NDArray[np.int_] | Sequence[int],
     lep_per_round: npt.NDArray[np.float64] | Sequence[float],
     lep_stddev_per_round: npt.NDArray[np.float64] | Sequence[float],
-) -> LambdaResults:
+) -> LambdaData:
     """Compute Λ, Λ_0 and their associated standard deviations by fitting
     ``lep_per_round`` to ``1 / Λ_0 * Λ**(-(distance + 1) / 2)`` directly.
 
@@ -159,7 +159,7 @@ def _lambda_fit_with_direct(
         maxfev=10000,
     )
     lamb0_stddev, lamb_stddev = np.sqrt(np.diagonal(cov))
-    return LambdaResults(
+    return LambdaData(
         float(lamb), float(lamb_stddev), float(lamb0), float(lamb0_stddev)
     )
 
@@ -178,7 +178,7 @@ def calculate_lambda_and_lambda_stddev(
     lep_per_round: npt.NDArray[np.float64] | Sequence[float],
     lep_stddev_per_round: npt.NDArray[np.float64] | Sequence[float],
     method: Literal["d", "(d+1)/2", "direct"] = "(d+1)/2",
-) -> LambdaResults:
+) -> LambdaData:
     """Calculate the error suppression factor (Λ) and its standard deviation.
 
     Requires the logical error probability (LEP) per round (which may be approximated
@@ -213,7 +213,7 @@ def calculate_lambda_and_lambda_stddev(
             2 should be preferred in general.
 
     Returns:
-        LambdaResults: detailed results of the computation.
+        LambdaData: detailed results of the computation.
 
     Note:
         For values of Λ very close to 1 (``abs(Λ - 1) < 1e-7``) and

--- a/deltakit-explorer/src/deltakit_explorer/analysis/error_budget/_post_processing.py
+++ b/deltakit-explorer/src/deltakit_explorer/analysis/error_budget/_post_processing.py
@@ -11,7 +11,7 @@ from deltakit_explorer.analysis import (
 )
 from deltakit_explorer.analysis._analysis import calculate_lep_and_lep_stddev
 from deltakit_explorer.analysis._lambda import (
-    LambdaResults,
+    LambdaData,
     calculate_lambda_and_lambda_stddev,
 )
 
@@ -76,7 +76,7 @@ def compute_lambda_and_stddev_from_results(
 def _compute_lambda_from_results(
     num_rounds_by_distance: Mapping[int, Sequence[int]],
     data: pd.DataFrame,
-) -> LambdaResults:
+) -> LambdaData:
     lepprs: list[float] = []
     leppr_stddevs: list[float] = []
     distances = sorted(num_rounds_by_distance.keys())

--- a/deltakit-explorer/src/deltakit_explorer/plotting/_lambda.py
+++ b/deltakit-explorer/src/deltakit_explorer/plotting/_lambda.py
@@ -7,7 +7,7 @@ from deltakit_core.plotting.colours import RIVERLANE_PLOT_COLOURS
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
-from deltakit_explorer.analysis._lambda import LambdaResults as LambdaData
+from deltakit_explorer.analysis._lambda import LambdaData
 from deltakit_explorer.plotting.plotting import plot
 from deltakit_explorer.plotting.results import interpolate_lambda
 

--- a/deltakit-explorer/src/deltakit_explorer/plotting/results.py
+++ b/deltakit-explorer/src/deltakit_explorer/plotting/results.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 import numpy as np
 import numpy.typing as npt
 
-from deltakit_explorer.analysis._lambda import LambdaResults as LambdaData
+from deltakit_explorer.analysis._lambda import LambdaData
 from deltakit_explorer.analysis._leppr import (
     LogicalErrorProbabilityPerRoundResults as LEPPRData,
 )

--- a/deltakit-explorer/tests/conftest.py
+++ b/deltakit-explorer/tests/conftest.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from deltakit_explorer._utils._utils import DELTAKIT_SERVER_URL_ENV
-from deltakit_explorer.analysis._lambda import LambdaResults
+from deltakit_explorer.analysis._lambda import LambdaData
 from deltakit_explorer.analysis._leppr import LogicalErrorProbabilityPerRoundResults
 
 
@@ -21,8 +21,8 @@ def random_generator():
 
 
 @pytest.fixture
-def lambda_results() -> LambdaResults:
-    return LambdaResults(
+def lambda_results() -> LambdaData:
+    return LambdaData(
         lambda_=3.0,
         lambda_stddev=0.1,
         lambda0=1.5,


### PR DESCRIPTION
## 🔗 Closed Issues

Closes #234. 

---

## 📝 Description

This PR addresses the name ambiguity between `LambdaResult` and `LambdaResults`. 

---

## 🚦 Status

Ready for review. 

---

## 🛠️ Future Work

Address #233 in following.
