### PR TITLE
chore(decode): lower minimum requirement for plotly to 5.0

### DIFF
--- a/deltakit-decode/pyproject.toml
+++ b/deltakit-decode/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "networkx~=3.1",
   "seaborn~=0.12",
   "matplotlib~=3.5",
-  "plotly~=6.5",
+  "plotly >=5.0, <7.0",
   "pymatching~=2.2",
   "pymatching>=2.2.2,~=2.2; python_version >= '3.13'",
   "stim>=1.12; python_version < '3.12'",


### PR DESCRIPTION
## 🔗 Closed Issues

#249

---

## 📝 Description

This PR lowers the minimum requirement for the `plotly` package. See #249 for how this has been tested.

---

## 🚦 Status

Ready to merge.

---

## 🛠️ Future Work

None

---

## ➕️ Additional Information

I used the `>=A, <B` dependency requirement to be sure that we do not declare ourselves compatible with a potentially future breaking version.

---

## 🧾 Release Note

chore(decode): lower minimum requirement for plotly to 5.0
