### PR TITLE
fix(other): typo in documentation

### DIFF
--- a/docs/examples/notebooks/demo/2. quick start.ipynb
+++ b/docs/examples/notebooks/demo/2. quick start.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "In an error corrected circuit `qubit0` becomes a set of qubits (aka data qubits). Unlike in classical error correction, these qubits\n",
     "cannot be measured while executing the algorithm, without disrupting the calculations. That is why data qubits are sneakily followed by ancillary qubits.\n",
-    "Ancillary qubits entagle with neighbouring data qubits and perform the role of parity check. Every round of an experiment we measure\n",
+    "Ancillary qubits entangle with neighbouring data qubits and perform the role of parity check. Every round of an experiment we measure\n",
     "ancillary qubits to learn if a state flip happened to their neighbours.\n",
     "\n",
     "QEC codes define which qubits perform which roles and how they entangle. Decoders use ancillary qubit measurements to predict corruption of a logical state."


### PR DESCRIPTION
## 🔗 Closed Issues

None 

---

## 📝 Description

This PR fixes a typo that was caught on a `dependabot` PR actions (https://github.com/Deltakit/deltakit/actions/runs/25706783080/job/75478559347?pr=253).

---

## 🚦 Status

Ready to merge.

---

## 🛠️ Future Work

None

---

## ➕️ Additional Information

None

---

## 🧾 Release Note

fix(other): typo in documentation