### PR TITLE
  refactor(plotting): make plot() a pure dispatcher to the specialised plotters

### DIFF
--- a/deltakit-explorer/src/deltakit_explorer/plotting/_helpers.py
+++ b/deltakit-explorer/src/deltakit_explorer/plotting/_helpers.py
@@ -1,0 +1,61 @@
+# (c) Copyright Riverlane 2020-2025.
+"""Shared rendering helpers for the specialised plotting functions."""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import numpy.typing as npt
+from deltakit_core.plotting.colours import RIVERLANE_PLOT_COLOURS
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+from deltakit_explorer.plotting.results import Interpolated
+
+
+def setup_fig_ax(fig: Figure | None, ax: Axes | None) -> tuple[Figure, Axes]:
+    """Validate a ``fig`` / ``ax`` pair, creating them if both are None.
+
+    Args:
+        fig: An existing matplotlib Figure, or None.
+        ax: An existing matplotlib Axes, or None.
+
+    Returns:
+        The figure and axes to draw on.
+
+    Raises:
+        ValueError: If exactly one of ``fig`` and ``ax`` is None.
+    """
+    if (fig is None) ^ (ax is None):
+        msg = "The 'fig' and 'ax' parameters should either be both `None` or both set."
+        raise ValueError(msg)
+    if fig is None or ax is None:
+        fig, ax = plt.subplots()
+    return fig, ax
+
+
+def draw_fit(
+    ax: Axes, x_values: npt.NDArray[np.floating], result: Interpolated
+) -> None:
+    """Draw an interpolated fit curve and its confidence band onto ``ax``.
+
+    Args:
+        ax: The axes to draw on.
+        x_values: The x coordinates of the interpolated curve.
+        result: The interpolated values and confidence boundaries to draw.
+    """
+    ax.plot(
+        x_values,
+        result.interpolated,
+        label=result.fit_label,
+        color=RIVERLANE_PLOT_COLOURS[1],
+    )
+    ax.fill_between(
+        x_values,
+        result.lower_boundary,
+        result.upper_boundary,
+        label=result.confidence_interval_label,
+        color=RIVERLANE_PLOT_COLOURS[0],
+        alpha=0.2,
+    )
+    ax.legend()

--- a/deltakit-explorer/src/deltakit_explorer/plotting/_lambda.py
+++ b/deltakit-explorer/src/deltakit_explorer/plotting/_lambda.py
@@ -1,79 +1,68 @@
-import matplotlib.pyplot as plt
 from deltakit_core.plotting.colours import RIVERLANE_PLOT_COLOURS
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
 from deltakit_explorer.analysis import LambdaData
-from deltakit_explorer.plotting.plotting import plot
-from deltakit_explorer.plotting.results import interpolate_lambda
+from deltakit_explorer.plotting._helpers import draw_fit, setup_fig_ax
+from deltakit_explorer.plotting.results import LambdaResult, interpolate_lambda
 
 
 def plot_lambda(
-    lambda_data: LambdaData,
+    lambda_data: LambdaData | LambdaResult,
     *,
     num_sigmas: int = 3,
     num_points: int = 200,
     fig: Figure | None = None,
     ax: Axes | None = None,
+    title: str | None = None,
 ) -> tuple[Figure, Axes]:
-    """Interpolate and plot Λ-fitted data.
+    """Plot a Λ fit and its confidence band.
 
-    This function interpolates and plots both the logical error-probability per round that has been used
-    to compute Λ, the associated error-rates if provided, and the resulting fit, showing
-    how close the fit is from actual data.
+    When ``lambda_data`` is raw :class:`LambdaData`, the per-distance error
+    probabilities are drawn and the fit is interpolated. When it is an already
+    interpolated :class:`LambdaResult`, it is rendered directly.
 
     Args:
-        lambda_data: Result of a fit containing Λ, Λ₀, their standard deviations, and the original data.
+        lambda_data: A Λ fit, either as raw data or an interpolated result.
         num_sigmas: Number of standard deviations for the error band. Default 3.
         num_points: Number of interpolation points. Default 200.
-        fig: A matplotlib Figure object to plot on. If None, a new figure
-            will be created. Default is None.
-        ax: A matplotlib Axes object to plot on. If None, a new axes will
-            be created. Default is None.
+        fig: A matplotlib Figure to plot on. If None, a new figure is created.
+        ax: A matplotlib Axes to plot on. If None, a new axes is created.
+        title: An optional custom title for the plot.
 
     Returns:
         The matplotlib Figure and Axes objects containing the plot.
 
     Example:
-        from deltakit_explorer.analysis import calculate_lambda_and_lambda_std
+        from deltakit_explorer.analysis import calculate_lambda_and_lambda_stddev
 
-        lambda_data = calculate_lambda_and_lambda_std(
+        lambda_data = calculate_lambda_and_lambda_stddev(
             distances=[5, 7, 9],
             leppr=[0.15, 0.1, 0.05],
-            leppr_stddev=[0.01, 0.008, 0.005],
+            leppr_std=[0.01, 0.008, 0.005],
         )
-        fig, ax = plot_lambda(
-            lambda_data=lambda_data,
-        )
+        fig, ax = plot_lambda(lambda_data)
         ax.set_yscale("log")
-        plt.show()
     """
-    if (fig is None) ^ (ax is None):
-        msg = "The 'fig' and 'ax' parameters should either be both None or both set."
-        raise ValueError(msg)
+    fig, ax = setup_fig_ax(fig, ax)
 
-    if fig is None and ax is None:
-        fig, ax = plt.subplots()
+    if isinstance(lambda_data, LambdaResult):
+        result = lambda_data
+    else:
+        ax.errorbar(
+            lambda_data.distances,
+            lambda_data.leppr,
+            yerr=lambda_data.leppr_std * num_sigmas,
+            fmt=".",
+            color=RIVERLANE_PLOT_COLOURS[1],
+            label=f"Logical error probabilities per round (±{num_sigmas}σ)",  # noqa: RUF001
+        )
+        result = interpolate_lambda(
+            lambda_data, num_sigmas=num_sigmas, num_points=num_points
+        )
 
-    # These should be already checked by the above code, but type checkers are not able
-    # to infer that information, so including the asserts explicitly for type checkers
-    # to understand.
-    assert ax is not None
-    assert fig is not None
-
-    # Plot the logical error probabilities per round
-    ax.errorbar(
-        lambda_data.distances,
-        lambda_data.leppr,
-        yerr=lambda_data.leppr_std * num_sigmas,
-        fmt=".",
-        color=RIVERLANE_PLOT_COLOURS[1],
-        label=f"Logical error probabilities per round (±{num_sigmas}σ)",  # noqa: RUF001
-    )
-
-    lambda_result = interpolate_lambda(
-        lambda_data, num_sigmas=num_sigmas, num_points=num_points
-    )
-
-    plot(lambda_result, fig=fig, ax=ax)
+    draw_fit(ax, result.distances, result)
+    ax.set_title(title if title is not None else "Error Suppression Factor Λ")
+    ax.set_xlabel("Code distance")
+    ax.set_ylabel("Logical Error Probability per Round")
     return fig, ax

--- a/deltakit-explorer/src/deltakit_explorer/plotting/_leppr.py
+++ b/deltakit-explorer/src/deltakit_explorer/plotting/_leppr.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
+from typing import overload
 
-import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 from deltakit_core.plotting.colours import RIVERLANE_PLOT_COLOURS
@@ -8,10 +8,25 @@ from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
 from deltakit_explorer.analysis import LogicalErrorProbabilityPerRoundData as LEPPRData
-from deltakit_explorer.plotting.plotting import plot
+from deltakit_explorer.plotting._helpers import draw_fit, setup_fig_ax
+from deltakit_explorer.plotting.results import (
+    LogicalErrorProbabilityPerRoundResult as LEPPRResult,
+)
 from deltakit_explorer.plotting.results import interpolate_leppr
 
 
+@overload
+def plot_logical_error_probability_per_round(
+    leppr_data: LEPPRResult,
+    *,
+    num_sigmas: int = 3,
+    fig: Figure | None = None,
+    ax: Axes | None = None,
+    title: str | None = None,
+) -> tuple[Figure, Axes]: ...
+
+
+@overload
 def plot_logical_error_probability_per_round(
     leppr_data: LEPPRData,
     num_rounds: npt.NDArray[np.int_] | Sequence[int],
@@ -23,96 +38,93 @@ def plot_logical_error_probability_per_round(
     num_sigmas: int = 3,
     fig: Figure | None = None,
     ax: Axes | None = None,
+    title: str | None = None,
+) -> tuple[Figure, Axes]: ...
+
+
+def plot_logical_error_probability_per_round(
+    leppr_data: LEPPRData | LEPPRResult,
+    num_rounds: npt.NDArray[np.int_] | Sequence[int] | None = None,
+    logical_error_probability: npt.NDArray[np.float64] | Sequence[float] | None = None,
+    logical_error_probability_stddev: (
+        npt.NDArray[np.float64] | Sequence[float] | None
+    ) = None,
+    *,
+    num_sigmas: int = 3,
+    fig: Figure | None = None,
+    ax: Axes | None = None,
+    title: str | None = None,
 ) -> tuple[Figure, Axes]:
-    """Plot the logical error probability per round data and the fitted curve.
+    """Plot a logical error probability per round fit and its confidence band.
+
+    When ``leppr_data`` is raw :class:`LogicalErrorProbabilityPerRoundData`, the
+    measured data points are drawn and the fit is interpolated; ``num_rounds`` and
+    ``logical_error_probability`` are required in that case. When it is an already
+    interpolated result, it is rendered directly.
 
     Args:
-        leppr_data: Data class containing logical error probability per round
-            fit results.
-        num_rounds: a sequence of integers representing the number of rounds
-            used to get the corresponding results in ``num_failed_shots`` and
-            ``num_shots``.
-        logical_error_probability: a sequence of floats representing the logical
-            error probabilities corresponding to the number of rounds in
-            ``num_rounds``.
-        logical_error_probability_stddev: a sequence of floats representing the
-            standard deviation of the logical error probabilities corresponding
-            to the number of rounds in ``num_rounds``. If None, no error bars
-            will be plotted. Default is None.
-        num_sigmas: number of sigmas to consider when plotting error bars.
-        fig: a matplotlib Figure object to plot on. If None, a new figure
-            will be created. Default is None.
-        ax: a matplotlib Axes object to plot on. If None, a new axes will
-            be created. Default is None.
+        leppr_data: A LEPPR fit, either as raw data or an interpolated result.
+        num_rounds: The number of rounds for each measured point. Required for raw
+            data, ignored for an interpolated result.
+        logical_error_probability: The measured logical error probabilities.
+            Required for raw data, ignored for an interpolated result.
+        logical_error_probability_stddev: The standard deviation of each measured
+            point. If None, no error bars are drawn on the data points.
+        num_sigmas: Number of sigmas for the error bars and band.
+        fig: A matplotlib Figure to plot on. If None, a new figure is created.
+        ax: A matplotlib Axes to plot on. If None, a new axes is created.
+        title: An optional custom title for the plot.
 
     Returns:
         The matplotlib Figure and Axes objects containing the plot.
 
-    Example:
-
-        >>> from deltakit_explorer.analysis import (
-        ...     calculate_lep_and_lep_stddev,
-        ...     compute_logical_error_per_round,
-        ... )
-        >>> num_failed_shots = [34, 151, 356]
-        >>> num_shots = [500000] * 3
-        >>> num_rounds = [2, 4, 6]
-        >>> res = compute_logical_error_per_round(
-        ...     num_failed_shots=num_failed_shots,
-        ...     num_shots=num_shots,
-        ...     num_rounds=num_rounds,
-        ... )
-        >>> lep, lep_stddev = calculate_lep_and_lep_stddev(
-        ...     fails=num_failed_shots, shots=num_shots
-        ... )
-        >>> fig, ax = plot_logical_error_probability_per_round(
-        ...     res,
-        ...     num_rounds=num_rounds,
-        ...     logical_error_probability=lep,
-        ...     logical_error_probability_stddev=lep_stddev,
-        ... )
+    Raises:
+        ValueError: If raw data is passed without ``num_rounds`` and
+            ``logical_error_probability``, or if the data lengths do not match.
     """
-    if (fig is None) ^ (ax is None):
-        msg = "The 'fig' and 'ax' parameters should either be both None or both set."
-        raise ValueError(msg)
+    fig, ax = setup_fig_ax(fig, ax)
 
-    if fig is None and ax is None:
-        fig, ax = plt.subplots()
+    if isinstance(leppr_data, LEPPRResult):
+        result = leppr_data
+    else:
+        if num_rounds is None or logical_error_probability is None:
+            msg = (
+                "num_rounds and logical_error_probability are required when plotting "
+                "raw logical error probability per round data."
+            )
+            raise ValueError(msg)
 
-    assert ax is not None
-    assert fig is not None
+        lens = {len(num_rounds), len(logical_error_probability)}
+        if logical_error_probability_stddev is not None:
+            lens.add(len(logical_error_probability_stddev))
+        if len(lens) > 1:
+            msg = (
+                "The lengths of 'num_rounds', 'logical_error_probability' and "
+                "'logical_error_probability_stddev' must be the same. Got the "
+                f"following lengths: {lens}."
+            )
+            raise ValueError(msg)
 
-    lens = {len(num_rounds), len(logical_error_probability)}
-    if logical_error_probability_stddev is not None:
-        lens.add(len(logical_error_probability_stddev))
-    if len(lens) > 1:
-        msg = (
-            "The lengths of 'num_rounds', 'logical_error_probability' and "
-            "'logical_error_probability_stddev' must be the same. Got the following "
-            f"lengths: {lens}."
+        isort = np.argsort(num_rounds)
+        num_rounds = np.asarray(num_rounds)[isort]
+        logical_error_probability = np.asarray(logical_error_probability)[isort]
+        yerr = (
+            None
+            if logical_error_probability_stddev is None
+            else num_sigmas * np.asarray(logical_error_probability_stddev)[isort]
         )
-        raise ValueError(msg)
-
-    isort = np.argsort(num_rounds)
-    num_rounds = np.asarray(num_rounds)[isort]
-    logical_error_probability = np.asarray(logical_error_probability)[isort]
-    if logical_error_probability_stddev is not None:
-        logical_error_probability_stddev = (
-            num_sigmas * np.asarray(logical_error_probability_stddev)[isort]
+        ax.errorbar(
+            num_rounds,
+            logical_error_probability,
+            yerr=yerr,
+            fmt=".",
+            color=RIVERLANE_PLOT_COLOURS[0],
+            label=f"Logical error probabilities (±{num_sigmas}σ)",  # noqa: RUF001
         )
+        result = interpolate_leppr(leppr_data, num_sigmas=num_sigmas)
 
-    # Plot the logical error probabilities
-    ax.errorbar(
-        num_rounds,
-        logical_error_probability,
-        yerr=logical_error_probability_stddev,
-        fmt=".",
-        color=RIVERLANE_PLOT_COLOURS[0],
-        label=f"Logical error probabilities (±{num_sigmas}σ)",  # noqa: RUF001
-    )
-
-    leppr_result = interpolate_leppr(leppr_data, num_rounds, num_sigmas=num_sigmas)
-
-    plot(leppr_result, fig=fig, ax=ax)
-
+    draw_fit(ax, result.rounds, result)
+    ax.set_title(title if title is not None else "Logical Error Probability per Round")
+    ax.set_xlabel("Rounds")
+    ax.set_ylabel("Logical Error Probability")
     return fig, ax

--- a/deltakit-explorer/src/deltakit_explorer/plotting/plotting.py
+++ b/deltakit-explorer/src/deltakit_explorer/plotting/plotting.py
@@ -3,11 +3,13 @@
 
 from __future__ import annotations
 
-import matplotlib.pyplot as plt
-from deltakit_core.plotting.colours import RIVERLANE_PLOT_COLOURS
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
+from deltakit_explorer.plotting._lambda import plot_lambda
+from deltakit_explorer.plotting._leppr import (
+    plot_logical_error_probability_per_round,
+)
 from deltakit_explorer.plotting.results import LambdaResult
 from deltakit_explorer.plotting.results import (
     LogicalErrorProbabilityPerRoundResult as LEPPRResult,
@@ -21,95 +23,50 @@ def plot(
     ax: Axes | None = None,
     title: str | None = None,
 ) -> tuple[Figure, Axes]:
-    """Generic plot function that dispatches to specialised plotting based on the
-    result type.
+    """Plot a precomputed result by dispatching to the matching specialised plotter.
 
-    This function inspects the type of ``result`` and calls the appropriate
-    rendering logic:
-
-    - `LambdaResult`: Render error-suppression factor Λ fit curve with error bands.
-    - `LEPPRResult`: Renders the logical error probability per round fit curve with error bands.
-
-    This enables users to compute the plot data separately (via `interpolate_lambda` or `interpolate_leppr`) and then render with a single call.
+    ``plot`` inspects the type of ``result`` and forwards it to the function that
+    owns the rendering for that type, so a precomputed result (from
+    ``interpolate_lambda`` or ``interpolate_leppr``) can be drawn with a single
+    call.
 
     Args:
         result: The precomputed plot data.
-        fig: An existing matplotlib Figure. If None,
-            a new figure will be created. Default is None.
-        ax: An existing matplotlib Axes. If None, a new
-            axes will be created. Default is None.
-        title: An optional custom title for the plot. If None,
-            a default title based on the result type will be used.
+        fig: An existing matplotlib Figure. If None, a new figure is created.
+        ax: An existing matplotlib Axes. If None, a new axes is created.
+        title: An optional custom title for the plot.
 
     Returns:
         The matplotlib Figure and Axes objects containing the plot.
 
     Raises:
-        ValueError: If ``fig`` and ``ax`` are not both None or both set.
         TypeError: If the ``result`` type is not supported.
 
     Examples:
-
-        Plotting a Lambda fit curve::
+        Plot a precomputed Λ fit::
 
             from deltakit_explorer.plotting.results import interpolate_lambda
 
-            lambda_result = interpolate_lambda(lambda_data, distances)
+            lambda_result = interpolate_lambda(lambda_data)
             fig, ax = plot(lambda_result)
 
-        Plotting a LEPPR fit curve::
+        Plot a precomputed LEPPR fit::
 
             from deltakit_explorer.plotting.results import interpolate_leppr
 
-            leppr_result = interpolate_leppr(leppr_data, num_rounds)
+            leppr_result = interpolate_leppr(leppr_data)
             fig, ax = plot(leppr_result)
-
     """
-    if (fig is None) ^ (ax is None):
-        msg = "The 'fig' and 'ax' parameters should either be both `None` or both set."
-        raise ValueError(msg)
-
-    if fig is None and ax is None:
-        fig, ax = plt.subplots()
-
-    assert ax is not None
-    assert fig is not None
-
     match result:
         case LambdaResult():
-            x_vals = result.distances
-            xlabel = "Code distance"
-            ylabel = "Logical Error Probability per Round"
-            default_title = "Error Suppression Factor Λ"
+            return plot_lambda(result, fig=fig, ax=ax, title=title)
         case LEPPRResult():
-            x_vals = result.rounds
-            xlabel = "Rounds"
-            ylabel = "Logical Error Probability"
-            default_title = "Logical Error Probability per Round"
+            return plot_logical_error_probability_per_round(
+                result, fig=fig, ax=ax, title=title
+            )
         case _:
             msg = (
                 f"Unsupported result type: {type(result).__name__}. "
                 "Expected `LambdaResult` or `LEPPRResult`."
             )
             raise TypeError(msg)
-
-    ax.plot(
-        x_vals,
-        result.interpolated,
-        label=result.fit_label,
-        color=RIVERLANE_PLOT_COLOURS[1],
-    )
-    ax.fill_between(
-        x_vals,
-        result.lower_boundary,
-        result.upper_boundary,
-        label=result.confidence_interval_label,
-        color=RIVERLANE_PLOT_COLOURS[0],
-        alpha=0.2,
-    )
-    ax.set_title(title if title is not None else default_title)
-    ax.set_xlabel(xlabel)
-    ax.set_ylabel(ylabel)
-    ax.legend()
-
-    return fig, ax

--- a/deltakit-explorer/tests/plotting/test_results_and_plot.py
+++ b/deltakit-explorer/tests/plotting/test_results_and_plot.py
@@ -6,6 +6,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
+from deltakit_explorer.plotting import (
+    plot_lambda,
+    plot_logical_error_probability_per_round,
+)
 from deltakit_explorer.plotting.plotting import plot
 from deltakit_explorer.plotting.results import (
     LambdaResult,
@@ -122,3 +126,41 @@ class TestPlot:
     def test_plot_raises_on_unsupported_type(self):
         with pytest.raises(TypeError, match="Unsupported result type"):
             plot("invalid")
+
+
+class TestSpecialisedPlottersOwnRendering:
+    def test_plot_lambda_accepts_raw_data(self, lambda_results):
+        fig, _ = plot_lambda(lambda_results)
+        assert fig is not None
+        plt.close(fig)
+
+    def test_plot_lambda_accepts_interpolated_result(self, lambda_results):
+        result = interpolate_lambda(lambda_results)
+        fig, _ = plot_lambda(result)
+        assert fig is not None
+        plt.close(fig)
+
+    def test_plot_leppr_accepts_interpolated_result(self, leppr_results):
+        result = interpolate_leppr(leppr_results)
+        fig, _ = plot_logical_error_probability_per_round(result)
+        assert fig is not None
+        plt.close(fig)
+
+    def test_plot_leppr_raw_renders(self, leppr_results, num_rounds):
+        lep = np.array([0.1, 0.2, 0.3])
+        fig, _ = plot_logical_error_probability_per_round(
+            leppr_results, num_rounds, lep
+        )
+        assert fig is not None
+        plt.close(fig)
+
+    def test_plot_leppr_raw_requires_measured_points(self, leppr_results):
+        with pytest.raises(ValueError, match="required when plotting raw"):
+            plot_logical_error_probability_per_round(leppr_results)
+
+    def test_dispatch_matches_direct_call_title(self, lambda_results):
+        result = interpolate_lambda(lambda_results)
+        _, dispatched = plot(result)
+        _, direct = plot_lambda(result)
+        assert dispatched.get_title() == direct.get_title()
+        plt.close("all")


### PR DESCRIPTION

  ## 🔗 Closed Issues

  Closes #233

  ---

  ## 📝 Description

  Reverses the call direction so the generic `plot()` dispatches to the specialised
  plotters, instead of the specialised plotters routing back through `plot()`. Each
  specialised function now owns its rendering and accepts either raw data or an
  already-interpolated result; shared figure/axes setup and band drawing live in a
  small `_helpers` module.

  While doing this it also fixes a `TypeError` in
  `plot_logical_error_probability_per_round`, where `interpolate_leppr` was called
  with `num_rounds` as a positional argument.

  I'm aware of #268, which addresses the same issue. I'm opening this as a smaller
  alternative (+253/-192 vs +347/-155) with the extra bug fix and `@overload`-typed
  signatures. Happy to defer to #268 if the maintainers prefer it.

  ---

  ## 🚦 Status

  Ready for review. Green locally against the pinned tooling: `ruff`, `mypy`,
  `pydoclint`, and the full plotting test suite (existing behaviour preserved, new
  dispatch/raw-vs-result tests added).
  
  ---

  ## 🛠️  Future Work

  None required for this change. The detection-probability and other plotting work
  tracked under #163 can build on the same dispatcher.

  ---

  ## ➕️ Additional Information

  Public API is unchanged for existing callers: `plot_lambda` and
  `plot_logical_error_probability_per_round` keep working with raw data, and now
  also accept an interpolated result so `plot()` can route to them. The new
  `_helpers` module (`setup_fig_ax`, `draw_fit`) is private.

  ---
  
  ## 🧾 Release Note

  refactor(plotting): make plot() a pure dispatcher to the specialised plotters
