### PR TITLE
feat: plot detection probability on code patches

### DIFF
--- a/deltakit-explorer/src/deltakit_explorer/plotting/__init__.py
+++ b/deltakit-explorer/src/deltakit_explorer/plotting/__init__.py
@@ -6,6 +6,9 @@ from deltakit_explorer.plotting._correlation_matrix import (
     defect_diagram,
     defect_rates,
 )
+from deltakit_explorer.plotting._detection_probability import (
+    plot_detection_probability_on_patch,
+)
 from deltakit_explorer.plotting._lambda import plot_lambda
 from deltakit_explorer.plotting._leppr import plot_leppr
 from deltakit_explorer.plotting.plotting import plot

--- a/deltakit-explorer/src/deltakit_explorer/plotting/__init__.py
+++ b/deltakit-explorer/src/deltakit_explorer/plotting/__init__.py
@@ -7,6 +7,7 @@ from deltakit_explorer.plotting._correlation_matrix import (
     defect_rates,
 )
 from deltakit_explorer.plotting._detection_probability import (
+    DetectionProbabilityAggregation,
     plot_detection_probability_on_patch,
 )
 from deltakit_explorer.plotting._lambda import plot_lambda

--- a/deltakit-explorer/src/deltakit_explorer/plotting/_detection_probability.py
+++ b/deltakit-explorer/src/deltakit_explorer/plotting/_detection_probability.py
@@ -4,12 +4,13 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from enum import Enum
 from itertools import chain
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
-from deltakit_circuit import PauliX
+from deltakit_circuit import Coord2D, PauliX
 from matplotlib.axes import Axes
 from matplotlib.colors import Normalize
 from matplotlib.figure import Figure
@@ -19,28 +20,61 @@ if TYPE_CHECKING:
     from deltakit_explorer.codes._planar_code import PlanarCode
     from deltakit_explorer.codes._stabiliser import Stabiliser
 
-Aggregation = Literal["mean", "median", "variance"]
+
+class DetectionProbabilityAggregation(Enum):
+    """Reduction applied to per-round detection probabilities.
+
+    Attributes:
+        MEAN: Arithmetic mean across all rounds.
+        MEDIAN: Median across all rounds.
+        VARIANCE: Variance across steady-state rounds, excluding the first and last.
+    """
+
+    MEAN = "mean"
+    MEDIAN = "median"
+    VARIANCE = "variance"
 
 
 def _aggregate_detection_probabilities(
     detection_probabilities: Mapping[tuple[float, ...], Sequence[float]],
     *,
-    aggregation: Aggregation = "mean",
+    aggregation: DetectionProbabilityAggregation = DetectionProbabilityAggregation.MEAN,
     round_index: int | None = None,
-) -> dict[tuple[float, float], float]:
-    """Reduce per-round detector probabilities to one value per coordinate."""
-    aggregated: dict[tuple[float, float], float] = {}
+) -> dict[Coord2D, float]:
+    """Reduce per-round detector probabilities to one value per coordinate.
+
+    Args:
+        detection_probabilities: Detector coordinates mapped to per-round values.
+        aggregation: Reduction to apply when ``round_index`` is not provided.
+        round_index: Optional round to select instead of aggregating.
+
+    Returns:
+        Detection probability or variance keyed by spatial detector coordinate.
+
+    Raises:
+        ValueError: If detector coordinates, probabilities, or the round are invalid.
+    """
+    aggregated: dict[Coord2D, float] = {}
     for coordinate, rates in detection_probabilities.items():
         if len(coordinate) < 2:
             msg = f"Detector coordinate {coordinate!r} must contain x and y values."
             raise ValueError(msg)
 
         values = np.asarray(rates, dtype=float)
+        if values.ndim != 1:
+            msg = f"Detector coordinate {coordinate!r} must have one value per round."
+            raise ValueError(msg)
         if values.size == 0:
             msg = f"Detector coordinate {coordinate!r} has no probability values."
             raise ValueError(msg)
         if not np.all(np.isfinite(values)):
             msg = f"Detector coordinate {coordinate!r} contains a non-finite value."
+            raise ValueError(msg)
+        if np.any((values < 0) | (values > 1)):
+            msg = (
+                f"Detector coordinate {coordinate!r} contains a probability "
+                "outside [0, 1]."
+            )
             raise ValueError(msg)
 
         if round_index is not None:
@@ -52,26 +86,25 @@ def _aggregate_detection_probabilities(
                     f"coordinate {coordinate!r}."
                 )
                 raise ValueError(msg) from error
-        elif aggregation == "mean":
+        elif aggregation is DetectionProbabilityAggregation.MEAN:
             value = float(np.mean(values))
-        elif aggregation == "median":
+        elif aggregation is DetectionProbabilityAggregation.MEDIAN:
             value = float(np.median(values))
-        elif aggregation == "variance":
+        elif aggregation is DetectionProbabilityAggregation.VARIANCE:
             if values.size < 3:
                 msg = (
                     "Variance requires at least three rounds so the first and last "
                     "rounds can be excluded."
                 )
                 raise ValueError(msg)
+            # State preparation and final measurement make the boundary rounds
+            # expected outliers, so variance describes only the steady-state rounds.
             value = float(np.var(values[1:-1]))
         else:
-            msg = (
-                f"Unknown aggregation {aggregation!r}; expected 'mean', 'median', "
-                "or 'variance'."
-            )
+            msg = f"Unknown aggregation {aggregation!r}."
             raise ValueError(msg)
 
-        aggregated[(float(coordinate[0]), float(coordinate[1]))] = value
+        aggregated[Coord2D(float(coordinate[0]), float(coordinate[1]))] = value
 
     if not aggregated:
         msg = "detection_probabilities is empty; there is nothing to plot."
@@ -80,7 +113,17 @@ def _aggregate_detection_probabilities(
 
 
 def _stabiliser_vertices(stabiliser: Stabiliser) -> list[tuple[float, float]]:
-    """Return ordered vertices for the stabiliser's plaquette."""
+    """Return ordered vertices for the stabiliser's plaquette.
+
+    Args:
+        stabiliser: Stabiliser whose data-qubit geometry should be drawn.
+
+    Returns:
+        Plaquette vertices ordered anticlockwise around their center.
+
+    Raises:
+        ValueError: If the stabiliser lacks the geometry required for a plaquette.
+    """
     coordinates = [
         (
             float(pauli.qubit.unique_identifier[0]),
@@ -112,9 +155,19 @@ def _stabiliser_vertices(stabiliser: Stabiliser) -> list[tuple[float, float]]:
 
 def _find_detection_probability(
     stabiliser: Stabiliser,
-    probabilities: Mapping[tuple[float, float], float],
+    probabilities: Mapping[Coord2D, float],
     tolerance: float,
 ) -> float | None:
+    """Match a stabiliser ancilla to an aggregated detector probability.
+
+    Args:
+        stabiliser: Stabiliser whose ancilla coordinate should be matched.
+        probabilities: Aggregated probabilities keyed by spatial coordinate.
+        tolerance: Absolute coordinate matching tolerance.
+
+    Returns:
+        Matching probability, or ``None`` when no coordinate matches.
+    """
     if stabiliser.ancilla_qubit is None:
         return None
     ancilla = cast(Sequence[float], stabiliser.ancilla_qubit.unique_identifier)
@@ -133,7 +186,7 @@ def plot_detection_probability_on_patch(
     code: PlanarCode,
     detection_probabilities: Mapping[tuple[float, ...], Sequence[float]],
     *,
-    aggregation: Aggregation = "mean",
+    aggregation: DetectionProbabilityAggregation = DetectionProbabilityAggregation.MEAN,
     round_index: int | None = None,
     cmap: str = "viridis",
     vmin: float | None = None,
@@ -153,7 +206,8 @@ def plot_detection_probability_on_patch(
         detection_probabilities: Detector coordinates mapped to per-round
             detection probabilities.
         aggregation: Reduction used when ``round_index`` is not provided.
-            Variance excludes the first and last rounds.
+            ``VARIANCE`` excludes the first and last rounds because state
+            preparation and final measurement make them expected outliers.
         round_index: Optional round to plot instead of aggregating all rounds.
         cmap: Matplotlib colour map used for detection probabilities.
         vmin: Optional lower limit for the shared colour scale.
@@ -255,7 +309,7 @@ def plot_detection_probability_on_patch(
         label = (
             f"Detection probability (round {round_index})"
             if round_index is not None
-            else f"Detection probability ({aggregation})"
+            else f"Detection probability ({aggregation.value})"
         )
         colour_bar.set_label(label)
 

--- a/deltakit-explorer/src/deltakit_explorer/plotting/_detection_probability.py
+++ b/deltakit-explorer/src/deltakit_explorer/plotting/_detection_probability.py
@@ -1,0 +1,262 @@
+# (c) Copyright Riverlane 2020-2026.
+"""Plot detector probabilities directly on a planar-code patch."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from itertools import chain
+from typing import TYPE_CHECKING, Literal, cast
+
+import matplotlib.pyplot as plt
+import numpy as np
+from deltakit_circuit import PauliX
+from matplotlib.axes import Axes
+from matplotlib.colors import Normalize
+from matplotlib.figure import Figure
+from matplotlib.patches import Circle, Polygon
+
+if TYPE_CHECKING:
+    from deltakit_explorer.codes._planar_code import PlanarCode
+    from deltakit_explorer.codes._stabiliser import Stabiliser
+
+Aggregation = Literal["mean", "median", "variance"]
+
+
+def _aggregate_detection_probabilities(
+    detection_probabilities: Mapping[tuple[float, ...], Sequence[float]],
+    *,
+    aggregation: Aggregation = "mean",
+    round_index: int | None = None,
+) -> dict[tuple[float, float], float]:
+    """Reduce per-round detector probabilities to one value per coordinate."""
+    aggregated: dict[tuple[float, float], float] = {}
+    for coordinate, rates in detection_probabilities.items():
+        if len(coordinate) < 2:
+            msg = f"Detector coordinate {coordinate!r} must contain x and y values."
+            raise ValueError(msg)
+
+        values = np.asarray(rates, dtype=float)
+        if values.size == 0:
+            msg = f"Detector coordinate {coordinate!r} has no probability values."
+            raise ValueError(msg)
+        if not np.all(np.isfinite(values)):
+            msg = f"Detector coordinate {coordinate!r} contains a non-finite value."
+            raise ValueError(msg)
+
+        if round_index is not None:
+            try:
+                value = float(values[round_index])
+            except IndexError as error:
+                msg = (
+                    f"Round index {round_index} is out of range for detector "
+                    f"coordinate {coordinate!r}."
+                )
+                raise ValueError(msg) from error
+        elif aggregation == "mean":
+            value = float(np.mean(values))
+        elif aggregation == "median":
+            value = float(np.median(values))
+        elif aggregation == "variance":
+            if values.size < 3:
+                msg = (
+                    "Variance requires at least three rounds so the first and last "
+                    "rounds can be excluded."
+                )
+                raise ValueError(msg)
+            value = float(np.var(values[1:-1]))
+        else:
+            msg = (
+                f"Unknown aggregation {aggregation!r}; expected 'mean', 'median', "
+                "or 'variance'."
+            )
+            raise ValueError(msg)
+
+        aggregated[(float(coordinate[0]), float(coordinate[1]))] = value
+
+    if not aggregated:
+        msg = "detection_probabilities is empty; there is nothing to plot."
+        raise ValueError(msg)
+    return aggregated
+
+
+def _stabiliser_vertices(stabiliser: Stabiliser) -> list[tuple[float, float]]:
+    """Return ordered vertices for the stabiliser's plaquette."""
+    coordinates = [
+        (
+            float(pauli.qubit.unique_identifier[0]),
+            float(pauli.qubit.unique_identifier[1]),
+        )
+        for pauli in stabiliser.paulis
+        if pauli is not None
+    ]
+    if stabiliser.ancilla_qubit is None:
+        msg = "Detection probabilities require stabilisers with ancilla qubits."
+        raise ValueError(msg)
+
+    if len(coordinates) == 2:
+        ancilla = cast(
+            Sequence[float],
+            stabiliser.ancilla_qubit.unique_identifier,
+        )
+        coordinates.append((float(ancilla[0]), float(ancilla[1])))
+    elif len(coordinates) < 3:
+        msg = "A stabiliser plaquette needs at least two data qubits."
+        raise ValueError(msg)
+
+    center = np.mean(np.asarray(coordinates), axis=0)
+    return sorted(
+        coordinates,
+        key=lambda point: np.arctan2(point[1] - center[1], point[0] - center[0]),
+    )
+
+
+def _find_detection_probability(
+    stabiliser: Stabiliser,
+    probabilities: Mapping[tuple[float, float], float],
+    tolerance: float,
+) -> float | None:
+    if stabiliser.ancilla_qubit is None:
+        return None
+    ancilla = cast(Sequence[float], stabiliser.ancilla_qubit.unique_identifier)
+    for coordinate, probability in probabilities.items():
+        if np.allclose(
+            coordinate,
+            (float(ancilla[0]), float(ancilla[1])),
+            atol=tolerance,
+            rtol=0,
+        ):
+            return probability
+    return None
+
+
+def plot_detection_probability_on_patch(
+    code: PlanarCode,
+    detection_probabilities: Mapping[tuple[float, ...], Sequence[float]],
+    *,
+    aggregation: Aggregation = "mean",
+    round_index: int | None = None,
+    cmap: str = "viridis",
+    vmin: float | None = None,
+    vmax: float | None = None,
+    ax: Axes | None = None,
+    show_colorbar: bool = True,
+    show_data_qubits: bool = True,
+    coordinate_tolerance: float = 1e-6,
+) -> tuple[Figure, Axes]:
+    """Plot detection probabilities as filled stabiliser plaquettes.
+
+    The plot preserves the code geometry, including triangular boundary
+    plaquettes, and can be drawn into an existing axes for use as an inset.
+
+    Args:
+        code: Planar code whose stabiliser patch should be drawn.
+        detection_probabilities: Detector coordinates mapped to per-round
+            detection probabilities.
+        aggregation: Reduction used when ``round_index`` is not provided.
+            Variance excludes the first and last rounds.
+        round_index: Optional round to plot instead of aggregating all rounds.
+        cmap: Matplotlib colour map used for detection probabilities.
+        vmin: Optional lower limit for the shared colour scale.
+        vmax: Optional upper limit for the shared colour scale.
+        ax: Existing axes to draw into. A new figure is created when omitted.
+        show_colorbar: Whether to add a detection-probability colour bar.
+        show_data_qubits: Whether to draw data qubits over the plaquettes.
+        coordinate_tolerance: Absolute tolerance when matching detector and
+            ancilla coordinates.
+
+    Returns:
+        Figure and axes containing the patch plot.
+
+    Raises:
+        ValueError: If the probabilities are invalid or do not match the code.
+    """
+    probabilities = _aggregate_detection_probabilities(
+        detection_probabilities,
+        aggregation=aggregation,
+        round_index=round_index,
+    )
+    stabilisers = tuple(chain.from_iterable(code.stabilisers))
+    matched = [
+        (stabiliser, probability)
+        for stabiliser in stabilisers
+        if (
+            probability := _find_detection_probability(
+                stabiliser,
+                probabilities,
+                coordinate_tolerance,
+            )
+        )
+        is not None
+    ]
+    if not matched:
+        msg = "Detector coordinates do not match any stabiliser ancilla coordinates."
+        raise ValueError(msg)
+
+    values = np.asarray([probability for _, probability in matched])
+    lower = float(np.min(values)) if vmin is None else vmin
+    upper = float(np.max(values)) if vmax is None else vmax
+    if lower > upper:
+        msg = f"vmin ({lower}) cannot be greater than vmax ({upper})."
+        raise ValueError(msg)
+    if lower == upper:
+        padding = max(abs(lower) * 0.05, 0.01)
+        lower -= padding
+        upper += padding
+
+    if ax is None:
+        figure, axes = plt.subplots()
+    else:
+        axes = ax
+        figure = cast(Figure, axes.get_figure())
+
+    norm = Normalize(vmin=lower, vmax=upper)
+    colour_map = plt.get_cmap(cmap)
+    all_vertices: list[tuple[float, float]] = []
+    for stabiliser, probability in matched:
+        vertices = _stabiliser_vertices(stabiliser)
+        all_vertices.extend(vertices)
+        paulis = [pauli for pauli in stabiliser.paulis if pauli is not None]
+        edge_colour = "#b3261e" if isinstance(paulis[0], PauliX) else "#1557a0"
+        axes.add_patch(
+            Polygon(
+                vertices,
+                closed=True,
+                facecolor=colour_map(norm(probability)),
+                edgecolor=edge_colour,
+                linewidth=1.2,
+                zorder=1,
+            )
+        )
+
+    if show_data_qubits:
+        for qubit in code.data_qubits:
+            coordinate = qubit.unique_identifier
+            axes.add_patch(
+                Circle(
+                    (float(coordinate[0]), float(coordinate[1])),
+                    radius=0.16,
+                    facecolor="white",
+                    edgecolor="#202020",
+                    linewidth=0.8,
+                    zorder=2,
+                )
+            )
+
+    x_coordinates, y_coordinates = zip(*all_vertices, strict=True)
+    axes.set_xlim(min(x_coordinates) - 0.6, max(x_coordinates) + 0.6)
+    axes.set_ylim(min(y_coordinates) - 0.6, max(y_coordinates) + 0.6)
+    axes.set_aspect("equal")
+    axes.axis("off")
+
+    if show_colorbar:
+        mappable = plt.cm.ScalarMappable(norm=norm, cmap=colour_map)
+        mappable.set_array([])
+        colour_bar = figure.colorbar(mappable, ax=axes, fraction=0.05, pad=0.04)
+        label = (
+            f"Detection probability (round {round_index})"
+            if round_index is not None
+            else f"Detection probability ({aggregation})"
+        )
+        colour_bar.set_label(label)
+
+    return figure, axes

--- a/deltakit-explorer/tests/plotting/test_detection_probability.py
+++ b/deltakit-explorer/tests/plotting/test_detection_probability.py
@@ -3,12 +3,19 @@ from itertools import chain
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+from deltakit_circuit import Coord2D
 from matplotlib.patches import Polygon
 
 from deltakit_explorer.codes import RotatedPlanarCode
-from deltakit_explorer.plotting import plot_detection_probability_on_patch
+from deltakit_explorer.codes._stabiliser import Stabiliser
+from deltakit_explorer.plotting import (
+    DetectionProbabilityAggregation,
+    plot_detection_probability_on_patch,
+)
 from deltakit_explorer.plotting._detection_probability import (
     _aggregate_detection_probabilities,
+    _find_detection_probability,
+    _stabiliser_vertices,
 )
 
 
@@ -30,33 +37,136 @@ def _rates_for_code(
 @pytest.mark.parametrize(
     ("aggregation", "round_index", "expected"),
     [
-        ("mean", None, 2.5),
-        ("median", None, 2.5),
-        ("variance", None, 0.25),
-        ("mean", 1, 2.0),
-        ("mean", -1, 4.0),
+        (DetectionProbabilityAggregation.MEAN, None, 0.25),
+        (DetectionProbabilityAggregation.MEDIAN, None, 0.25),
+        (DetectionProbabilityAggregation.VARIANCE, None, 0.0025),
+        (DetectionProbabilityAggregation.MEAN, 1, 0.2),
+        (DetectionProbabilityAggregation.MEAN, -1, 0.4),
     ],
 )
 def test_aggregate_detection_probabilities(
-    aggregation: str,
+    aggregation: DetectionProbabilityAggregation,
     round_index: int | None,
     expected: float,
 ) -> None:
     values = _aggregate_detection_probabilities(
-        {(1.0, 2.0): [1.0, 2.0, 3.0, 4.0]},
+        {(1.0, 2.0): [0.1, 0.2, 0.3, 0.4]},
         aggregation=aggregation,
         round_index=round_index,
     )
 
-    assert values == {(1.0, 2.0): expected}
+    assert values == {Coord2D(1.0, 2.0): pytest.approx(expected)}
 
 
 def test_variance_requires_an_interior_round() -> None:
     with pytest.raises(ValueError, match="at least three rounds"):
         _aggregate_detection_probabilities(
-            {(1.0, 2.0): [1.0, 2.0]},
-            aggregation="variance",
+            {(1.0, 2.0): [0.1, 0.2]},
+            aggregation=DetectionProbabilityAggregation.VARIANCE,
         )
+
+
+@pytest.mark.parametrize(
+    ("probabilities", "message"),
+    [
+        ({}, "empty"),
+        ({(1.0,): [0.1]}, "x and y"),
+        ({(1.0, 2.0): []}, "no probability values"),
+        ({(1.0, 2.0): [[0.1]]}, "one value per round"),
+        ({(1.0, 2.0): [np.nan]}, "non-finite"),
+        ({(1.0, 2.0): [-0.1]}, r"outside \[0, 1\]"),
+        ({(1.0, 2.0): [1.1]}, r"outside \[0, 1\]"),
+    ],
+)
+def test_aggregate_detection_probabilities_rejects_invalid_data(
+    probabilities: dict[tuple[float, ...], list[float] | list[list[float]]],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        _aggregate_detection_probabilities(probabilities)
+
+
+def test_aggregate_detection_probabilities_rejects_missing_round() -> None:
+    with pytest.raises(ValueError, match="out of range"):
+        _aggregate_detection_probabilities(
+            {(1.0, 2.0): [0.1]},
+            round_index=2,
+        )
+
+
+def test_stabiliser_vertices_include_boundary_ancilla() -> None:
+    code = RotatedPlanarCode(3, 3)
+    stabilisers = tuple(chain.from_iterable(code.stabilisers))
+    boundary = next(
+        stabiliser for stabiliser in stabilisers if len(stabiliser.data_qubits) == 2
+    )
+
+    vertices = _stabiliser_vertices(boundary)
+    ancilla = boundary.ancilla_qubit
+
+    assert ancilla is not None
+    assert len(vertices) == 3
+    assert (
+        float(ancilla.unique_identifier.x),
+        float(ancilla.unique_identifier.y),
+    ) in vertices
+
+
+def test_stabiliser_vertices_order_interior_plaquette() -> None:
+    code = RotatedPlanarCode(3, 3)
+    stabilisers = tuple(chain.from_iterable(code.stabilisers))
+    interior = next(
+        stabiliser for stabiliser in stabilisers if len(stabiliser.data_qubits) == 4
+    )
+
+    vertices = _stabiliser_vertices(interior)
+    center = np.mean(np.asarray(vertices), axis=0)
+    angles = [
+        np.arctan2(vertex[1] - center[1], vertex[0] - center[0]) for vertex in vertices
+    ]
+
+    assert len(vertices) == 4
+    assert angles == sorted(angles)
+
+
+def test_find_detection_probability_uses_coordinate_tolerance() -> None:
+    code = RotatedPlanarCode(3, 3)
+    stabiliser = next(chain.from_iterable(code.stabilisers))
+    ancilla = stabiliser.ancilla_qubit
+
+    assert ancilla is not None
+    probabilities = {
+        Coord2D(
+            ancilla.unique_identifier.x + 5e-7,
+            ancilla.unique_identifier.y - 5e-7,
+        ): 0.25
+    }
+
+    assert _find_detection_probability(stabiliser, probabilities, 1e-6) == 0.25
+    assert _find_detection_probability(stabiliser, probabilities, 1e-8) is None
+
+
+def test_find_detection_probability_without_ancilla_returns_none() -> None:
+    code = RotatedPlanarCode(3, 3)
+    stabiliser = Stabiliser(next(chain.from_iterable(code.stabilisers)).paulis)
+
+    assert stabiliser.ancilla_qubit is None
+    assert (
+        _find_detection_probability(
+            stabiliser,
+            {Coord2D(0.0, 0.0): 0.25},
+            1e-6,
+        )
+        is None
+    )
+
+
+def test_stabiliser_vertices_requires_ancilla() -> None:
+    code = RotatedPlanarCode(3, 3)
+    stabiliser = Stabiliser(next(chain.from_iterable(code.stabilisers)).paulis)
+
+    with pytest.raises(ValueError, match="ancilla qubits"):
+        _stabiliser_vertices(stabiliser)
 
 
 def test_plot_detection_probability_fills_stabiliser_plaquettes() -> None:

--- a/deltakit-explorer/tests/plotting/test_detection_probability.py
+++ b/deltakit-explorer/tests/plotting/test_detection_probability.py
@@ -1,0 +1,131 @@
+from itertools import chain
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.patches import Polygon
+
+from deltakit_explorer.codes import RotatedPlanarCode
+from deltakit_explorer.plotting import plot_detection_probability_on_patch
+from deltakit_explorer.plotting._detection_probability import (
+    _aggregate_detection_probabilities,
+)
+
+
+def _rates_for_code(
+    code: RotatedPlanarCode,
+    values: list[float] | None = None,
+) -> dict[tuple[float, float], list[float]]:
+    rates = values or [0.1, 0.2, 0.3, 0.4]
+    return {
+        (
+            float(stabiliser.ancilla_qubit.unique_identifier.x),
+            float(stabiliser.ancilla_qubit.unique_identifier.y),
+        ): rates
+        for stabiliser in chain.from_iterable(code.stabilisers)
+        if stabiliser.ancilla_qubit is not None
+    }
+
+
+@pytest.mark.parametrize(
+    ("aggregation", "round_index", "expected"),
+    [
+        ("mean", None, 2.5),
+        ("median", None, 2.5),
+        ("variance", None, 0.25),
+        ("mean", 1, 2.0),
+        ("mean", -1, 4.0),
+    ],
+)
+def test_aggregate_detection_probabilities(
+    aggregation: str,
+    round_index: int | None,
+    expected: float,
+) -> None:
+    values = _aggregate_detection_probabilities(
+        {(1.0, 2.0): [1.0, 2.0, 3.0, 4.0]},
+        aggregation=aggregation,
+        round_index=round_index,
+    )
+
+    assert values == {(1.0, 2.0): expected}
+
+
+def test_variance_requires_an_interior_round() -> None:
+    with pytest.raises(ValueError, match="at least three rounds"):
+        _aggregate_detection_probabilities(
+            {(1.0, 2.0): [1.0, 2.0]},
+            aggregation="variance",
+        )
+
+
+def test_plot_detection_probability_fills_stabiliser_plaquettes() -> None:
+    code = RotatedPlanarCode(3, 3)
+
+    figure, axes = plot_detection_probability_on_patch(
+        code,
+        _rates_for_code(code),
+        show_colorbar=False,
+    )
+
+    stabilisers = tuple(chain.from_iterable(code.stabilisers))
+    polygons = [patch for patch in axes.patches if isinstance(patch, Polygon)]
+    polygon_vertex_counts = sorted(len(polygon.get_xy()) - 1 for polygon in polygons)
+    expected_vertex_counts = sorted(
+        len([pauli for pauli in stabiliser.paulis if pauli is not None])
+        + (1 if len(stabiliser.data_qubits) == 2 else 0)
+        for stabiliser in stabilisers
+    )
+
+    assert len(polygons) == len(stabilisers)
+    assert polygon_vertex_counts == expected_vertex_counts
+    assert axes.get_aspect() == 1.0
+    plt.close(figure)
+
+
+def test_plot_detection_probability_reuses_axes_for_inset() -> None:
+    code = RotatedPlanarCode(3, 3)
+    figure, axes = plt.subplots()
+    inset = axes.inset_axes([0.1, 0.1, 0.4, 0.4])
+
+    returned_figure, returned_axes = plot_detection_probability_on_patch(
+        code,
+        _rates_for_code(code),
+        ax=inset,
+        show_colorbar=False,
+    )
+
+    assert returned_figure is figure
+    assert returned_axes is inset
+    assert inset in axes.child_axes
+    plt.close(figure)
+
+
+def test_plot_detection_probability_rejects_unmatched_coordinates() -> None:
+    code = RotatedPlanarCode(3, 3)
+
+    with pytest.raises(ValueError, match="do not match"):
+        plot_detection_probability_on_patch(
+            code,
+            {(100.0, 100.0): [0.1]},
+        )
+
+
+def test_plot_detection_probability_uses_shared_colour_scale() -> None:
+    code = RotatedPlanarCode(3, 3)
+
+    figure, axes = plot_detection_probability_on_patch(
+        code,
+        _rates_for_code(code, [0.2]),
+        vmin=0.0,
+        vmax=1.0,
+    )
+
+    polygons = [patch for patch in axes.patches if isinstance(patch, Polygon)]
+    assert polygons
+    assert all(
+        np.allclose(polygon.get_facecolor(), polygons[0].get_facecolor())
+        for polygon in polygons
+    )
+    assert len(figure.axes) == 2
+    plt.close(figure)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,7 @@ depolarization = "depolarization"
 Authorization = "Authorization"   # Web-related field.
 color = "color"                   # Used in matplotlib and stim APIs.
 colors = "colors"
+Normalize = "Normalize"           # matplotlib.colors API
 optimize = "optimize"             # scipy.optimize
 ax = "ax"                         # Typical naming for matplotlib Axes instances.
 center = "center"


### PR DESCRIPTION
## Summary

- add `plot_detection_probability_on_patch` as a public plotting helper
- color the actual stabilizer plaquettes, including triangular boundary plaquettes
- support exact rounds plus mean, median, and interior-round variance aggregation
- allow plotting into an existing `Axes` for inset and composed figures
- validate empty, non-finite, out-of-range, and unmatched detector inputs

```python
fig, ax = plot_detection_probability_on_patch(
    RotatedPlanarCode(3, 3),
    detection_probabilities,
    aggregation=DetectionProbabilityAggregation.MEDIAN,
)
```

## Why

The plaquette geometry is the useful spatial signal here. Filling the same stabilizer polygons used by the code model makes boundary and interior behavior directly comparable without center markers obscuring the patch.

## Checks

- plotting suite: 45 passed
- full explorer suite: 14,510 passed
- Ruff check and format: passed
- mypy: passed for all 86 explorer source files
- pydoclint, typos, and deptry: passed
- `git diff --check` (passed)

Closes #135.

## AI disclosure

I used an LLM as a collaborative tool for repository triage, drafting tests, and reviewing edge cases. I inspected the existing plotting geometry, implemented and reviewed the code locally, and ran the checks listed above.
