### PR TITLE
fix(explorer): Fix auth test.

### DIFF
--- a/deltakit-explorer/tests/utils/test_auth.py
+++ b/deltakit-explorer/tests/utils/test_auth.py
@@ -33,32 +33,15 @@ def test_if_no_token_raises(mocker):
         _auth.get_token()
 
 
-@pytest.mark.skip(reason="Mark as skipped until #287 is fixed.")
 def test_http_verification_is_set():
+    # clear SSL verify variable
+    os.environ.pop(_auth.TLS_DISABLE_CHECK_VARIABLE, None)
+    # sets _auth.TLS_DISABLE_CHECK_VARIABLE to 'false'
     _auth.set_https_verification(True)
-    # wrong host certificate
-    url = "https://wrong.host.badssl.com/"
-    with pytest.raises(requests.exceptions.SSLError):
-        requests.get(
-            url,
-            verify=not _auth.https_verification_disabled(),
-            timeout=5,
-        )
+    val = os.environ.get(_auth.TLS_DISABLE_CHECK_VARIABLE)
+    assert val not in ["1", "yes", "true"]
 
 
-@pytest.mark.filterwarnings("ignore:Unverified HTTPS")
-def test_http_verification_is_unset():
-    # Related to `test_http_verification_is_set above`, but this time
-    # we don't require HTTPS verification, so we should *not* get an `SSLError`.
-    # An "Unverified HTTPS" warning is OK.
-    # (Sometimes we get a `ConnectionError`, though, and we don't want to
-    # fail because of that, so suppress it.)
-    _auth.set_https_verification(False)
-    # wrong host certificate
-    url = "https://wrong.host.badssl.com/"
-    with suppress(requests.exceptions.ConnectionError):
-        requests.get(
-            url,
-            verify=not _auth.https_verification_disabled(),
-            timeout=5,
-        )
+def test_https_verification_not_disabled_by_default():
+    # Assert SSH verification is disabled by default
+    assert _auth.https_verification_disabled() is False

--- a/deltakit-explorer/tests/utils/test_auth.py
+++ b/deltakit-explorer/tests/utils/test_auth.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 
 import os
 import random
-from contextlib import suppress
 
 import pytest
-import requests
 
 from deltakit_explorer._api import _auth
 from deltakit_explorer._utils import _utils as utils

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ tests_extras = [
   "pandas~=2.2,>=2.2.2",
 ]
 test = [
-  "pytest>=9.0",
+  "pytest>=9.0,<9.1.0",
   "pytest-cov>=7.0",
   "pytest-skip-slow>=0.0.5",
   { include-group = "tests_extras" },


### PR DESCRIPTION
## 🔗 Closed Issues

Closes #287.

---

## 📝 Description

The intention for problematic unit tests was to verify the `set_https_verification` function worked as expected. Underneath it just sets the `_auth.TLS_DISABLE_CHECK_VARIABLE` to false, this fix verifies this without making an http request.

Former tests more of validates requests library functionality rather than the function in question.

Also: pins the upper version for `pytest` as latest release breaks CI.

---

## 🚦 Status

Ready for review

---

## 🛠️ Future Work

NA

---

## ➕️ Additional Information

Anything that doesn't fit into a category above.

---

## 🧾 Release Note

If this PR will be **squash-merged**, draft the final one-line commit message here.
Otherwise, describe your rebase strategy or how you plan to maintain clean commits.
