### PR TITLE
fix(circuit): proper TICK placement with REPEAT

### DIFF
--- a/deltakit-circuit/src/deltakit_circuit/_circuit.py
+++ b/deltakit-circuit/src/deltakit_circuit/_circuit.py
@@ -539,7 +539,10 @@ class Circuit(Generic[T]):  # pylint: disable=too-many-public-methods
             # Append a tick after every gate layer but not after the last one
             if isinstance(layer, GateLayer) and layer is not last_gate_layer:
                 inner_stim_circuit.append("TICK")
-        stim_circuit += self.iterations * inner_stim_circuit
+        if self.iterations > 1:
+            inner_stim_circuit.append("TICK")
+            inner_stim_circuit = self.iterations * inner_stim_circuit
+        stim_circuit += inner_stim_circuit
 
     def as_detector_error_model(  # noqa: PLR0913
         self,

--- a/deltakit-circuit/tests/test_circuit.py
+++ b/deltakit-circuit/tests/test_circuit.py
@@ -1410,7 +1410,7 @@ class TestStimCircuit:
 
     def test_repeated_circuit_can_be_converted_into_correct_stim_circuit(self):
         circuit = sp.Circuit(sp.GateLayer(sp.gates.X(sp.Qubit(0))), iterations=4)
-        assert circuit.as_stim_circuit() == stim.Circuit("REPEAT 4 {\nX 0\n}")
+        assert circuit.as_stim_circuit() == stim.Circuit("REPEAT 4 {\nX 0\nTICK\n}")
 
     def test_deltakit_circuit_circuit_with_single_repeat_doesnt_create_stim_repeat_block(
         self,
@@ -1431,9 +1431,11 @@ class TestStimCircuit:
             TICK
             REPEAT 3 {
                 CX 0 1
+                TICK
             }
             REPEAT 5 {
                 CZ 0 1
+                TICK
             }
         """)
 
@@ -1451,7 +1453,9 @@ class TestStimCircuit:
                 TICK
                 REPEAT 3 {
                     CZ 0 1
+                    TICK
                 }
+                TICK
             }
         """)
 


### PR DESCRIPTION
## 🔗 Closed Issues

Closes #281

---

## 📝 Description

Insert the proper `TICK` instruction at the end of a repeat block.

No specific tests were added because the existing tests caught that change and are sufficiently covering it I think.

---

## 🚦 Status

Ready for review

---

## 🛠️ Future Work

None

---

## ➕️ Additional Information

None

---

## 🧾 Release Note

fix(circuit): proper TICK placement with REPEAT