### PR TITLE
fix: increase linkcheck_timeout to 180s to reduce flaky CI failures

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,5 +110,5 @@ suppress_warnings = [
     "autosummary.import_cycle",
 ]
 
-linkcheck_timeout = 60
+linkcheck_timeout = 180
 linkcheck_retries = 2


### PR DESCRIPTION
## 🔗 Closed Issues

Closes #290 

---

## 📝 Description

Increased the linkcheck_timeout from 60 to 180

---

## 🚦 Status

Ready for review

---

## 🛠️ Future Work

None

---

## ➕️ Additional Information

None

---

## 🧾 Release Note

None
