### PR TITLE
fix(dependencies): deltakit-stim>=0.2

### DIFF
--- a/deltakit-circuit/pyproject.toml
+++ b/deltakit-circuit/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "deltakit-stim>=0.1.2,<0.2",
+  "deltakit-stim>=0.2,<0.3",
   "typing-extensions~=4.0",
   "packaging>=25.0",
 ]
@@ -47,7 +47,13 @@ Changelog = "https://github.com/Deltakit/deltakit/releases"
 
 [dependency-groups]
 test = ["pytest>=9.0", "pytest-cov>=7.0", "pytest-skip-slow>=0.0.5"]
-lint = ["mypy~=1.17", "ruff~=0.14", "typos~=1.34", "deptry~=0.23", "pydoclint~=0.8"]
+lint = [
+  "mypy~=1.17",
+  "ruff~=0.14",
+  "typos~=1.34",
+  "deptry~=0.23",
+  "pydoclint~=0.8",
+]
 security = ["bandit~=1.8", "pip-audit~=2.7"]
 dev = [
   { include-group = "test" },
@@ -62,10 +68,6 @@ known_first_party = ["deltakit_circuit"]
 files = "src/**/*.py"
 # The below list of disabled checks should eventually be empty.
 disable_error_code = "dict-item,misc,arg-type,return-value,union-attr,index,attr-defined,call-overload"
-
-[[tool.mypy.overrides]]
-module = ["stim"]
-follow_untyped_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["./tests/"]

--- a/deltakit-core/pyproject.toml
+++ b/deltakit-core/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "numpy>=1.26",
   "numpy~=2.1; python_version >= '3.13'",
   "networkx~=3.1",
-  "deltakit-stim>=0.1.2,<0.2",
+  "deltakit-stim>=0.2,<0.3",
   "typing_extensions~=4.0",
   "packaging>=25.0",
 ]
@@ -75,21 +75,10 @@ dev = [
 [tool.deptry]
 known_first_party = ["deltakit_core"]
 
-[tool.deptry.per_rule_ignores]
-DEP001 = ["lestim"]
-
 [tool.mypy]
 files = "src/**/*.py"
 # The below list of disabled checks should eventually be empty.
 disable_error_code = "arg-type,attr-defined"
-
-[[tool.mypy.overrides]]
-module = ["stim"]
-follow_untyped_imports = true
-
-[[tool.mypy.overrides]]
-module = ["lestim"]
-ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["./tests/"]

--- a/deltakit-core/src/deltakit_core/decoding_graphs/_decoding_graph_tools.py
+++ b/deltakit-core/src/deltakit_core/decoding_graphs/_decoding_graph_tools.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable
 from collections.abc import Set as AbstractSet
 from typing import no_type_check
 
+import deltakit_stim as stim
 import networkx as nx
 import numpy as np
 
@@ -29,11 +30,6 @@ from deltakit_core.decoding_graphs._dem_parsing import (
     DetectorCounter,
     dem_to_decoding_graph_and_logicals,
 )
-
-try:
-    import lestim as stim
-except ImportError:
-    import deltakit_stim as stim
 
 
 def filter_to_data_edges(graph: NXDecodingGraph) -> list[DecodingEdge]:

--- a/deltakit-core/src/deltakit_core/decoding_graphs/_dem_parsing.py
+++ b/deltakit-core/src/deltakit_core/decoding_graphs/_dem_parsing.py
@@ -10,13 +10,8 @@ from collections.abc import Iterable, Iterator
 from itertools import chain, zip_longest
 from typing import Generic, Protocol, TypeVar, cast
 
+import deltakit_stim as stim
 from typing_extensions import Self
-
-try:
-    import lestim as stim
-except ImportError:
-    import deltakit_stim as stim
-
 
 from deltakit_core.decoding_graphs._data_qubits import (
     DecodingEdge,

--- a/deltakit-core/src/deltakit_core/decoding_graphs/_explained_dem_parsing.py
+++ b/deltakit-core/src/deltakit_core/decoding_graphs/_explained_dem_parsing.py
@@ -1,10 +1,7 @@
 # (c) Copyright Riverlane 2020-2025.
 from collections import defaultdict
 
-try:
-    import lestim as stim
-except ImportError:
-    import deltakit_stim as stim
+import deltakit_stim as stim
 
 from deltakit_core.decoding_graphs._decoding_graph import (
     AnyEdgeT,

--- a/deltakit-core/tests/unit/data_formats/test_b8_parser.py
+++ b/deltakit-core/tests/unit/data_formats/test_b8_parser.py
@@ -2,12 +2,8 @@
 import tempfile
 from pathlib import Path
 
+import deltakit_stim as stim
 import pytest
-
-try:
-    import lestim as stim
-except ImportError:
-    import deltakit_stim as stim
 
 from deltakit_core.data_formats import (
     b8_to_logical_flip,

--- a/deltakit-core/tests/unit/decoding_graphs/test_decoding_graph_tools.py
+++ b/deltakit-core/tests/unit/decoding_graphs/test_decoding_graph_tools.py
@@ -1,12 +1,8 @@
 # (c) Copyright Riverlane 2020-2025.
 from pathlib import Path
 
+import deltakit_stim as stim
 import pytest
-
-try:
-    import lestim as stim
-except ImportError:
-    import deltakit_stim as stim
 
 from deltakit_core.decoding_graphs import (
     DecodingEdge,

--- a/deltakit-core/tests/unit/decoding_graphs/test_dem_parsing.py
+++ b/deltakit-core/tests/unit/decoding_graphs/test_dem_parsing.py
@@ -3,12 +3,8 @@ from collections.abc import Iterable
 from itertools import chain
 from unittest.mock import MagicMock
 
+import deltakit_stim as stim
 import pytest
-
-try:
-    import lestim as stim
-except ImportError:
-    import deltakit_stim as stim
 from pytest_mock import MockerFixture
 
 from deltakit_core.decoding_graphs import (

--- a/deltakit-core/tests/unit/decoding_graphs/test_explained_dem_parsing.py
+++ b/deltakit-core/tests/unit/decoding_graphs/test_explained_dem_parsing.py
@@ -4,12 +4,8 @@ from __future__ import annotations
 import math
 from typing import Literal
 
+import deltakit_stim as stim
 import pytest
-
-try:
-    import lestim as stim
-except ImportError:
-    import deltakit_stim as stim
 from pytest_mock.plugin import MockerFixture
 
 from deltakit_core.decoding_graphs import (

--- a/deltakit-core/tests/unit/decoding_graphs/test_hypergraph_annotation_tools.py
+++ b/deltakit-core/tests/unit/decoding_graphs/test_hypergraph_annotation_tools.py
@@ -1,12 +1,8 @@
 """Unit tests for hypergraph annotation utilities focused on edge-based window ids."""
 
+import deltakit_stim as stim
 import networkx as nx
 import pytest
-
-try:
-    import lestim as stim
-except ImportError:
-    import deltakit_stim as stim
 
 from deltakit_core.decoding_graphs._decoding_graph import (
     DecodingCode,

--- a/deltakit-core/tests/unit/decoding_graphs/test_parse_stim_circuit.py
+++ b/deltakit-core/tests/unit/decoding_graphs/test_parse_stim_circuit.py
@@ -2,12 +2,8 @@
 # ("Riverlane") and is Riverlane Confidential Information.
 # (c) Copyright Riverlane 2021-2025. All rights reserved.
 
+import deltakit_stim as stim
 import pytest
-
-try:
-    import lestim as stim
-except ImportError:
-    import deltakit_stim as stim
 
 from deltakit_core.decoding_graphs._decoding_graph_tools import parse_stim_circuit
 

--- a/deltakit-core/tests/unit/decoding_graphs/test_parsing_dem_to_graphs.py
+++ b/deltakit-core/tests/unit/decoding_graphs/test_parsing_dem_to_graphs.py
@@ -1,12 +1,8 @@
 # (c) Copyright Riverlane 2020-2025.
 import math
 
+import deltakit_stim as stim
 import pytest
-
-try:
-    import lestim as stim
-except ImportError:
-    import deltakit_stim as stim
 
 from deltakit_core.decoding_graphs import (
     DecodingEdge,

--- a/deltakit-decode/pyproject.toml
+++ b/deltakit-decode/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
   "plotly >=5.0, <7.0",
   "pymatching~=2.2",
   "pymatching>=2.2.2,~=2.2; python_version >= '3.13'",
-  "deltakit-stim>=0.1.2,<0.2",
+  "deltakit-stim>=0.2,<0.3",
   "pathos~=0.3",
   # This is the first version to be compatible with numpy>=2.0 according to
   # https://pandas.pydata.org/pandas-docs/stable/whatsnew/v2.2.2.html
@@ -98,7 +98,7 @@ files = "src/**/*.py"
 disable_error_code = "arg-type,assignment,attr-defined,name-defined,index,misc"
 
 [[tool.mypy.overrides]]
-module = ["stim", "pathos", "pathos.pools", "pymatching"]
+module = ["pathos", "pathos.pools", "pymatching"]
 follow_untyped_imports = true
 
 [tool.pytest.ini_options]

--- a/deltakit-decode/src/deltakit_decode/noise_sources/_stim_noise_sources.py
+++ b/deltakit-decode/src/deltakit_decode/noise_sources/_stim_noise_sources.py
@@ -28,7 +28,7 @@ class StimNoise(
     MonteCarloNoise[stim.Circuit, StimErrorT],
 ):
     """A noise model that takes a set of noise profiles
-    that can be applied to a lestim circuit. These noise profiles
+    that can be applied to a deltakit_stim circuit. These noise profiles
     should be defined as callables that will be processed by deltakit_circuit.
 
     Parameters
@@ -73,17 +73,17 @@ class StimNoise(
         self._batch_size = batch_size
 
     def permute_stim_circuit(self, stim_circuit: stim.Circuit) -> stim.Circuit:
-        """Apply noise to a lestim circuit
+        """Apply noise to a deltakit_stim circuit
 
         Parameters
         ----------
         stim_circuit : stim.Circuit
-            The lestim circuit to manipulate with StimNoise's noise profiles
+            The deltakit_stim circuit to manipulate with StimNoise's noise profiles
 
         Returns
         -------
         stim.Circuit
-            A new lestim circuit with noise applied via the noise profiles
+            A new deltakit_stim circuit with noise applied via the noise profiles
         """
         circuit = sp.Circuit.from_stim_circuit(stim_circuit)
         circuit.remove_noise()
@@ -128,7 +128,7 @@ class StimNoise(
 
 
 class OptionedStim(StimNoise):
-    """A class with the ability to manipulate lestim circuits
+    """A class with the ability to manipulate deltakit_stim circuits
     with after clifford gate depolarisation, before measure
     flip probability and after reset flip probability. For
     more information on these noise profiles see:

--- a/deltakit-explorer/pyproject.toml
+++ b/deltakit-explorer/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
   "scipy~=1.15",
   # Upper bound due to github.com/Deltakit/deltakit/issues/284
   "matplotlib>=3.10,<3.11",
-  "deltakit-stim>=0.1.2,<0.2",
+  "deltakit-stim>=0.2,<0.3",
   "requests~=2.32",
   "tqdm~=4.66",
   "galois>=0.4.6,~=0.4",
@@ -104,10 +104,6 @@ known_first_party = ["deltakit_explorer"]
 files = "src/**/*.py"
 # The below list of disabled checks should eventually be empty.
 disable_error_code = "arg-type,assignment,attr-defined,dict-item,index,list-item,misc,operator,override,return-value,union-attr,var-annotated"
-
-[[tool.mypy.overrides]]
-module = ["stim"]
-follow_untyped_imports = true
 
 # The ldpc.mod2 stubs files contain syntax errors, and so make mypy fail earlier than expected
 # with a SyntaxError. Ignoring the whole module for mypy.

--- a/deltakit-explorer/src/deltakit_explorer/qpu/_circuits/_tableau_functions.py
+++ b/deltakit-explorer/src/deltakit_explorer/qpu/_circuits/_tableau_functions.py
@@ -252,7 +252,7 @@ def _get_tableau_from_sequence_of_gates(
         (
             stim.Tableau.from_named_gate(gate.stim_string)
             for gate in unitary_block[::-1]
-            # ensuring circuit order, since lestim assumes matrix order for mul
+            # ensuring circuit order, since deltakit_stim assumes matrix order for mul
         ),
         stim.Tableau.from_named_gate("I"),  # default in case unitary_block empty
     )
@@ -299,7 +299,7 @@ def _get_tableau_from_sequence_of_1q_gates(gates: Sequence[str]) -> stim.Tableau
             (
                 stim.Tableau.from_named_gate(gate)
                 for gate in gates[::-1]
-                # ensuring circuit order, since lestim assumes matrix order for mul
+                # ensuring circuit order, since deltakit_stim assumes matrix order for mul
             ),
         )
     except ValueError as ve:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,16 @@ test = [
   "pytest-skip-slow>=0.0.5",
   { include-group = "tests_extras" },
 ]
-lint = ["mypy>=1.17,<3.0", "ruff~=0.14", "typos~=1.34", "deptry~=0.23", "pydoclint~=0.8"]
+lint = [
+  "mypy>=1.17,<3.0",
+  "ruff~=0.14",
+  "typos~=1.34",
+  "deptry~=0.23",
+  "pydoclint~=0.8",
+]
 docs_extras = [
   "tqdm~=4.67",
-  "deltakit-stim>=0.1.2,<0.2",
+  "deltakit-stim>=0.2,<0.3",
   "numpy~=2.0",
   "matplotlib~=3.10,>=3.10.7",
   "pandas~=2.2,>=2.2.2",


### PR DESCRIPTION
## 🔗 Closed Issues

Require the new version of `deltakit-stim`, solving any interaction issue with `stim`.

---

## 📝 Description

This PR bumps `deltakit-stim` to `>=0.2` which is the first version with correct `stim` support https://github.com/Deltakit/deltakit-stim/releases/tag/v0.2.0.

---

## 🚦 Status

Ready to merge

---

## 🛠️ Future Work

None

---

## ➕️ Additional Information

None

---

## 🧾 Release Note

fix(dependencies): deltakit-stim>=0.2