### PR TITLE
chore(deps): udpate dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,27 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "uv"
+    directories:
+      - "/"
+      - "/deltakit-*"
     schedule:
       interval: "weekly"
+
+    commit-message:
+      prefix: fix(dependencies)
+      prefix-development: chore(dependencies)
+    # Grouping all development dependencies together, and all production libraries together.
+    groups:
+      dev-deps:
+        dependency-type: "development"
+      prod-deps:
+        dependency-type: "production"
+    # Deltakit dependencies should be updated when releasing, not by dependabot.
+    ignore:
+      - dependency-name: "deltakit*"
+    # Ideally, we would like "widen" here. Even though it is explicitly written as "supported" for
+    # uv in the documentation (https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--)
+    # it is not in practice...
+    # So sticking to the closest option we have for the moment, which is not ideal, but exists.
+    versioning-strategy: increase-if-necessary


### PR DESCRIPTION
## 🔗 Closed Issues

While addressing #296 I realised that only dev dependencies were bumped. 

---

## 📝 Description

This PR updates the dependabot configuration with a configuration that has already been tested on another repository.

---

## 🚦 Status

Ready for review.

---

## 🛠️ Future Work

None

---

## ➕️ Additional Information

None

---

## 🧾 Release Note

chore(deps): udpate dependabot configuration