### PR TITLE
fix: Increase link check timeout and remove reminiscent stim tests

### DIFF
--- a/deltakit-explorer/tests/unit/circuits/test_tableau_functions.py
+++ b/deltakit-explorer/tests/unit/circuits/test_tableau_functions.py
@@ -2,7 +2,6 @@ import random
 import re
 from copy import deepcopy
 from functools import reduce
-from importlib.metadata import version
 from operator import add, mul
 
 import deltakit_stim as stim
@@ -66,7 +65,6 @@ from deltakit_circuit.gates import (
     Z,
 )
 from deltakit_circuit.noise_channels import Depolarise2
-from packaging.version import Version
 
 from deltakit_explorer.codes._css._css_code_experiment_circuit import (
     css_code_memory_circuit,
@@ -101,7 +99,6 @@ from deltakit_explorer.qpu._circuits._tableau_functions import (
     _is_identity_like,
 )
 from deltakit_explorer.qpu._native_gate_set import NativeGateSet
-
 
 # define set of compilation dictionaries for testing
 compilation_dict0 = {("+X", "+Z"): ()}

--- a/deltakit-explorer/tests/unit/circuits/test_tableau_functions.py
+++ b/deltakit-explorer/tests/unit/circuits/test_tableau_functions.py
@@ -102,9 +102,6 @@ from deltakit_explorer.qpu._circuits._tableau_functions import (
 )
 from deltakit_explorer.qpu._native_gate_set import NativeGateSet
 
-CURRENT_STIM_VERSION = Version(version("stim"))
-STIM_VERSION_V1_13_0 = Version("1.13.0")
-
 
 # define set of compilation dictionaries for testing
 compilation_dict0 = {("+X", "+Z"): ()}
@@ -8919,14 +8916,6 @@ class TestTwoQubitGateCompilationDicts:
         )
         assert stim.Tableau.from_named_gate("CZ") == cz_with_unitaries_tableau
 
-    @pytest.mark.skipif(
-        CURRENT_STIM_VERSION < STIM_VERSION_V1_13_0,
-        reason=(
-            "CZSWAP gate has been introduced in Stim v1.13.0."
-            "See https://github.com/quantumlib/Stim/releases/tag/v1.13.0."
-            f"Current Stim version is {CURRENT_STIM_VERSION}."
-        ),
-    )
     @pytest.mark.parametrize("gate", list(GATE_TO_CZSWAP_DICT.keys()))
     def test_cpswap_to_czswap_dict_compilations_give_equivalent_tableaus(self, gate):
         ub1, ub2, ub3, ub4 = GATE_TO_CZSWAP_DICT[gate]
@@ -8960,14 +8949,6 @@ class TestTwoQubitGateCompilationDicts:
             == czswap_with_unitaries_tableau
         )
 
-    @pytest.mark.skipif(
-        CURRENT_STIM_VERSION < STIM_VERSION_V1_13_0,
-        reason=(
-            "CZSWAP gate has been introduced in Stim v1.13.0."
-            "See https://github.com/quantumlib/Stim/releases/tag/v1.13.0."
-            f"Current Stim version is {CURRENT_STIM_VERSION}."
-        ),
-    )
     @pytest.mark.parametrize("gate", list(CZSWAP_TO_GATE_DICT.keys()))
     def test_czswap_to_cpswap_dict_compilations_give_equivalent_tableaus(self, gate):
         ub1, ub2, ub3, ub4 = CZSWAP_TO_GATE_DICT[gate]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,5 +110,5 @@ suppress_warnings = [
     "autosummary.import_cycle",
 ]
 
-linkcheck_timeout = 180
+linkcheck_timeout = 360
 linkcheck_retries = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,9 +96,9 @@ dev = [
   "validate-pyproject>=0.24.1,<0.26.0",
 ]
 release = [
-  "tomlkit~=0.14",
+  "tomlkit<0.16,>=0.13",
   "pip-licenses>=5.0",
-  "python-semantic-release~=10.2",
+  "python-semantic-release>=10.6.1,<11",
 ]
 
 [tool.uv.workspace]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ dev = [
   "validate-pyproject>=0.24.1,<0.26.0",
 ]
 release = [
-  "tomlkit<0.16,>=0.13",
+  "tomlkit>=0.13,<0.16",
   "pip-licenses>=5.0",
   "python-semantic-release>=10.6.1,<11",
 ]


### PR DESCRIPTION
## 🔗 Closed Issues

Closes #313 

---

## 📝 Description

This PR addresses two points:
- [x] Increase link check time out to avoid failing CI.
- [x] Re-enable test now that Stim has been replaced by Deltakit-Stim 

---

## 🚦 Status

Ready to review.

---

## 🛠️ Future Work

Focused PRs are good!
Create and link issues for any follow-up work needed.

---

## ➕️ Additional Information

Anything that doesn't fit into a category above.

---

## 🧾 Release Note

If this PR will be **squash-merged**, draft the final one-line commit message here.
Otherwise, describe your rebase strategy or how you plan to maintain clean commits.
