### PR TITLE
fix(lint): bound ruff below 0.16 so static checks stop resolving a newer rule

### DIFF
--- a/deltakit-circuit/pyproject.toml
+++ b/deltakit-circuit/pyproject.toml
@@ -48,7 +48,7 @@ Changelog = "https://github.com/Deltakit/deltakit/releases"
 test = ["pytest>=9.0", "pytest-cov>=7.0", "pytest-skip-slow>=0.0.5"]
 lint = [
   "mypy>=1.17,<3.0",
-  "ruff~=0.14",
+  "ruff>=0.14,<0.16",
   "typos~=1.34",
   "deptry~=0.23",
   "pydoclint~=0.8",

--- a/deltakit-core/pyproject.toml
+++ b/deltakit-core/pyproject.toml
@@ -59,7 +59,7 @@ test = [
 ]
 lint = [
   "mypy>=1.17,<3.0",
-  "ruff~=0.14",
+  "ruff>=0.14,<0.16",
   "typos~=1.34",
   "deptry~=0.23",
   "types-networkx~=3.1",

--- a/deltakit-decode/pyproject.toml
+++ b/deltakit-decode/pyproject.toml
@@ -76,7 +76,7 @@ stubs = [
 ]
 lint = [
   "mypy>=1.17,<3.0",
-  "ruff~=0.14",
+  "ruff>=0.14,<0.16",
   "typos~=1.34",
   "deptry~=0.23",
   "pydoclint~=0.8",

--- a/deltakit-explorer/pyproject.toml
+++ b/deltakit-explorer/pyproject.toml
@@ -84,7 +84,7 @@ stubs = [
 ]
 lint = [
   "mypy>=1.17,<3.0",
-  "ruff~=0.14",
+  "ruff>=0.14,<0.16",
   "typos~=1.34",
   "deptry~=0.23",
   "pydoclint~=0.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ test = [
 ]
 lint = [
   "mypy>=1.17,<3.0",
-  "ruff~=0.14",
+  "ruff>=0.14,<0.16",
   "typos~=1.34",
   "deptry~=0.23",
   "pydoclint~=0.8",


### PR DESCRIPTION
## 🔗 Closed Issues

None. Filing this straight as a fix because lint CI is currently red on `main`. Happy to open an issue first instead if you would rather have one to link.

---

## 📝 Description

`ruff.toml` selects `PL`, so all of pylint applies, and `PLR0917` too-many-positional-arguments stabilised in **ruff 0.16.0**. The dev dependency was `ruff~=0.14`, which permits anything below 1.0, and `uv.lock` is not committed, so every CI run resolves fresh and now picks up 0.16.x.

Bisected against the current tree at `8c5d6a7`:

```
ruff 0.14.5   All checks passed!
ruff 0.15.0   All checks passed!
ruff 0.15.5   All checks passed!
ruff 0.16.0   Found 8 errors.     <- boundary
ruff 0.16.1   Found 8 errors.
```

Counts under 0.16.1, all of them `PLR0917`:

| project | errors |
| --- | --- |
| root | 64 |
| `deltakit-explorer` | 54 |
| `deltakit-decode` | 8 |
| `deltakit-circuit` | 2 |
| `deltakit-core` | 0 |

Run [30632090849](https://github.com/Deltakit/deltakit/actions/runs/30632090849) on `main` failed on `static-checks (deltakit-decode, ./deltakit-decode)` with the other four static-check jobs cancelled by fail-fast, while all eight test-matrix jobs passed. So this is the lint resolving a newer rule, not a change in the code.

The bound is written the way the other constraints here are written, `>=lower,<upper` rather than `~=`, matching `pytest>=9.0,<9.2.0` (#293) and `deltakit-stim>=0.2,<0.3` (#296).

---

## 🚦 Status

Ready. Nothing outstanding.

Verified locally on this branch, per package, exactly as `pull_request.yml` runs them (`uv sync --group=lint --group=security --package <p>` then `typos`, `ruff check`, `ruff format --check`, `pydoclint .`, `mypy`): all pass for the root project, `deltakit-core`, `deltakit-circuit`, `deltakit-decode` and `deltakit-explorer`. Resolved ruff is 0.15.22. Test suite was green before the change at `19599 passed, 6 skipped`.

Setup note in case it helps anyone else: `uv sync --all-extras --all-groups` at the workspace root is not enough to run the tests, because `pytest-mock` and `pytest-lazy-fixtures` are declared in per-package `dependency-groups`. `uv sync --all-packages --all-groups --all-extras` works.

---

## 🛠️ Future Work

This restores a deterministic lint without touching a single signature. **Whether to adopt `PLR0917` is a separate decision and it is yours**, since it is a judgement about these APIs across 128 call sites rather than a mechanical fix. Two ways I would be glad to prepare:

1. Set `[lint.pylint] max-positional-args` in `ruff.toml` to a threshold that suits the scientific APIs here, which keeps the rule and raises the bar.
2. Add `PLR0917` to `ignore` with a reason beside the existing `UP015` entry.

Say which and I will open it. Raising the ruff bound afterwards then becomes a normal dependency bump.

---

## ➕️ Additional Information

Worth knowing separately: because `uv.lock` is gitignored (`.gitignore:101`), any dev tool with a loose constraint can turn a green build red without a commit. Ruff is the one that fired today. That may be intentional, so I have not touched it.

---

## 🧾 Release Note

fix(lint): bound ruff below 0.16 so static checks stop resolving a newer rule

---

AI assistance (Claude, Anthropic) was used in developing this change. The design, review and verification were done by the author. Verified locally before submitting: the full `static-checks` command set from `pull_request.yml` for the root project and all four packages, and the test suite green at 19599 passed, 6 skipped.
