### PR TITLE
feat(core): implement weighted_nodes_within_radius

### DIFF
--- a/deltakit-core/src/deltakit_core/decoding_graphs/_windowing_utils.py
+++ b/deltakit-core/src/deltakit_core/decoding_graphs/_windowing_utils.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from collections import deque
 from collections.abc import Iterable
+from heapq import heapify, heappop, heappush
+from math import inf
 
 from deltakit_core.decoding_graphs._data_qubits import EdgeRecord
 from deltakit_core.decoding_graphs._decoding_graph import (
@@ -69,9 +71,56 @@ def weighted_nodes_within_radius(
     -------
     Set[int]
         Nodes reachable with total path weight <= ``radius``.
+
+    Raises
+    ------
+    ValueError
+        If ``radius`` is negative, or if growth reaches an edge whose weight is
+        negative. ``EdgeRecord.weight`` is ``log((1 - p_err) / p_err)``, so an
+        error mechanism with ``p_err > 0.5`` weighs less than nothing and the
+        shortest path is no longer well defined. Refusing is better than
+        returning a set that quietly depends on visit order.
+
+    Notes
+    -----
+    Cost is accumulated per edge traversed, so every vertex of a hyperedge is
+    the same distance from the vertex being left. A default ``EdgeRecord`` has
+    ``p_err`` of 0 and therefore infinite weight, which means an error mechanism
+    that never fires is infinitely far away and growth stops at it. That is the
+    intended reading, and it is why this is not interchangeable with
+    :func:`nodes_within_radius`, which counts hops.
     """
-    msg = "Weighted growth is not yet implemented."
-    raise NotImplementedError(msg)
+    if radius < 0:
+        msg = "Radius must be non-negative"
+        raise ValueError(msg)
+    best: dict[int, float] = dict.fromkeys(start_nodes, 0.0)
+    if radius == 0:
+        return set(best)
+    frontier: list[tuple[float, int]] = [(0.0, node) for node in best]
+    heapify(frontier)
+    while frontier:
+        distance, node = heappop(frontier)
+        if distance > best[node]:
+            continue
+        for edge in hypergraph.incident_edges(node):
+            weight = hypergraph.edge_records[edge].weight
+            if weight < 0:
+                vertices = tuple(sorted(edge.vertices))
+                msg = (
+                    f"Edge {vertices} has negative weight {weight}, so weighted "
+                    "growth has no well defined shortest path."
+                )
+                raise ValueError(msg)
+            reached = distance + weight
+            if reached > radius:
+                continue
+            for neighbour in edge.vertices:
+                if neighbour == node:
+                    continue
+                if reached < best.get(neighbour, inf):
+                    best[neighbour] = reached
+                    heappush(frontier, (reached, neighbour))
+    return set(best)
 
 
 def induce_subhypergraph(

--- a/deltakit-core/tests/unit/decoding_graphs/test_windowing_utils.py
+++ b/deltakit-core/tests/unit/decoding_graphs/test_windowing_utils.py
@@ -14,6 +14,7 @@ from deltakit_core.decoding_graphs._windowing_utils import (
     induce_subhypergraph,
     nodes_within_radius,
     relabel_hypergraph_nodes_contiguously,
+    weighted_nodes_within_radius,
 )
 
 
@@ -185,3 +186,76 @@ class TestExpandNodesToTimeSpan:
             detector_records={0: DetectorRecord(time=0), 1: DetectorRecord(time=1)},
         )
         assert expand_nodes_to_time_span(hg, set()) == set()
+
+
+class TestWeightedNodesWithinRadius:
+    """Weighted growth spends a budget of log-likelihood weight rather than hops.
+
+    ``EdgeRecord.weight`` is ``log((1 - p_err) / p_err)``, so p_err=0.1 costs
+    log(9), about 2.197, per edge traversed.
+    """
+
+    @staticmethod
+    def _chain(p_err: float = 0.1) -> DecodingHyperGraph:
+        return DecodingHyperGraph(
+            [
+                (DecodingHyperEdge((0, 1)), EdgeRecord(p_err=p_err)),
+                (DecodingHyperEdge((1, 2, 3)), EdgeRecord(p_err=p_err)),
+                (DecodingHyperEdge((3, 4)), EdgeRecord(p_err=p_err)),
+            ]
+        )
+
+    def test_budget_is_spent_per_edge_not_per_hop(self) -> None:
+        hg = self._chain()
+        step = EdgeRecord(p_err=0.1).weight
+        assert weighted_nodes_within_radius(hg, {0}, 0) == {0}
+        assert weighted_nodes_within_radius(hg, {0}, step * 0.9) == {0}
+        assert weighted_nodes_within_radius(hg, {0}, step) == {0, 1}
+        assert weighted_nodes_within_radius(hg, {0}, step * 2) == {0, 1, 2, 3}
+        assert weighted_nodes_within_radius(hg, {0}, step * 3) == {0, 1, 2, 3, 4}
+
+    def test_every_vertex_of_a_hyperedge_costs_the_same_to_reach(self) -> None:
+        # Nodes 2 and 3 sit on one hyperedge with node 1, so both are one edge
+        # weight away from 1 and neither is closer than the other.
+        hg = self._chain()
+        step = EdgeRecord(p_err=0.1).weight
+        assert weighted_nodes_within_radius(hg, {1}, step) == {1, 0, 2, 3}
+
+    def test_a_cheaper_route_wins_over_a_shorter_one(self) -> None:
+        # 0 to 3 is one expensive edge or two cheap ones. With a budget that
+        # only affords the cheap pair, 3 still has to be reached.
+        cheap, dear = 0.4, 0.001
+        hg = DecodingHyperGraph(
+            [
+                (DecodingHyperEdge((0, 3)), EdgeRecord(p_err=dear)),
+                (DecodingHyperEdge((0, 1)), EdgeRecord(p_err=cheap)),
+                (DecodingHyperEdge((1, 3)), EdgeRecord(p_err=cheap)),
+            ]
+        )
+        two_cheap = 2 * EdgeRecord(p_err=cheap).weight
+        assert two_cheap < EdgeRecord(p_err=dear).weight
+        assert weighted_nodes_within_radius(hg, {0}, two_cheap) == {0, 1, 3}
+
+    def test_an_impossible_error_mechanism_is_infinitely_far(self) -> None:
+        # A default EdgeRecord has p_err of 0, so its weight is infinite. No
+        # budget crosses it, which is the intended reading and the reason this
+        # is not interchangeable with the hop counter.
+        hg = DecodingHyperGraph([(DecodingHyperEdge((0, 1)), EdgeRecord())])
+        assert weighted_nodes_within_radius(hg, {0}, 1e12) == {0}
+        assert nodes_within_radius(hg, {0}, 1) == {0, 1}
+
+    def test_several_start_nodes_grow_together(self) -> None:
+        hg = self._chain()
+        step = EdgeRecord(p_err=0.1).weight
+        assert weighted_nodes_within_radius(hg, {0, 4}, step) == {0, 1, 3, 4}
+
+    def test_negative_radius_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="Radius must be non-negative"):
+            weighted_nodes_within_radius(self._chain(), {0}, -1.0)
+
+    def test_negative_edge_weight_is_refused_rather_than_guessed(self) -> None:
+        # p_err above 0.5 gives a negative weight, so there is no well defined
+        # shortest path and the answer would depend on visit order.
+        hg = DecodingHyperGraph([(DecodingHyperEdge((0, 1)), EdgeRecord(p_err=0.9))])
+        with pytest.raises(ValueError, match="negative weight"):
+            weighted_nodes_within_radius(hg, {0}, 5.0)


### PR DESCRIPTION
## 🔗 Closed Issues

Nothing closes with this. It is one of the small independent pieces #325 offers to do
on its own, and the one the sliding window in that proposal needs first.

---

## 📝 Description

`weighted_nodes_within_radius` is in `deltakit_core.decoding_graphs.__all__` and raises
`NotImplementedError`. It is the only `NotImplementedError` in `decoding_graphs`. Its
docstring already specifies the answer, "nodes reachable with total path weight
<= radius", so this implements exactly that: Dijkstra with a budget, sitting next to
`nodes_within_radius`, which counts hops.

Cost accumulates per edge traversed, so every vertex of a hyperedge is the same distance
from the vertex being left.

`EdgeRecord.weight` is `log((1 - p_err) / p_err)`. Two consequences of that belong in the
docstring rather than being left for a caller to discover, and both are tested.

- **`p_err` of 0, the `EdgeRecord` default, gives an infinite weight.** An error mechanism
  that never fires is infinitely far away and growth stops at it, so no budget crosses a
  default edge. That is the intended reading and it is why this is not a drop-in
  replacement for the hop counter. One test asserts the two functions differ on the same
  graph for that reason.
- **`p_err` above 0.5 gives a negative weight.** There is no well defined shortest path
  then, and the returned set would depend on visit order, so it raises `ValueError`
  naming the edge instead of returning something order-dependent.

A negative radius raises `ValueError` with the same message `nodes_within_radius` already
uses, and `radius == 0` returns the start nodes, so the two functions agree at their edges.

Seven tests in a new `TestWeightedNodesWithinRadius`:

| Test | What it pins |
| --- | --- |
| `test_budget_is_spent_per_edge_not_per_hop` | the budget buys edge weight, walked up in steps of `log(9)` |
| `test_every_vertex_of_a_hyperedge_costs_the_same_to_reach` | one hyperedge, one cost, for all of its vertices |
| `test_a_cheaper_route_wins_over_a_shorter_one` | two cheap edges beat one dear edge, so this is not BFS with weights bolted on |
| `test_an_impossible_error_mechanism_is_infinitely_far` | a default `EdgeRecord` stops growth where the hop version walks through |
| `test_several_start_nodes_grow_together` | multi-source, seeded at distance 0 |
| `test_negative_radius_is_refused` | matches the hop version's message |
| `test_negative_edge_weight_is_refused_rather_than_guessed` | `p_err = 0.9` raises rather than returning an order-dependent set |

Verified locally on this branch:

```
19606 passed, 6 skipped in 433.21s        # full suite, uv run pytest
                                          # 19599 passed, 6 skipped on 8c5d6a7
deltakit-core static checks, all clean:
  typos .                    (silent)
  ruff check .               All checks passed!
  ruff format --check .      36 files already formatted
  pydoclint .                🎉 No violations 🎉
  mypy .                     Success: no issues found in 36 source files
```

---

## 🚦 Status

Ready to review.

Correction, 2026-08-04: this section used to say `static-checks` was red on `main` over
`PLR0917` and that the other packages in the matrix would fail until #324 landed. That is
no longer true. 50ca5a3 added `PLR0917` to the package ruff configs, the matrix is green
with `ruff==0.16.1`, and #324 is closed as unnecessary. Nothing in this change ever
depended on it.

---

## 🛠️ Future Work

The sequential and parallel sliding-window decoders in #325, which use this together with
`annotate_edges_with_window_ids` and `get_window_id_transfer_graph`. Nothing else in
`_windowing_utils.py` is unimplemented after this.

---

## ➕️ Additional Information

Design decision worth flagging, because it is a judgement call rather than a
transcription of the docstring: an inclusive `<= radius` boundary is compared against a
float that was accumulated by addition. The tests therefore build their expected budgets
by the same arithmetic the function performs (`step`, `2 * step`) instead of hardcoding
decimals, so they pin behaviour rather than a rounding.

AI assistance (Claude, Anthropic) was used in developing this change. The design, review
and verification were done by the author. Verified locally before submitting: the full
`pytest` suite, plus `typos`, `ruff check`, `ruff format --check`, `pydoclint` and `mypy`
on `deltakit-core`, with the output quoted above.

---

## 🧾 Release Note

`feat(core): implement weighted_nodes_within_radius as bounded Dijkstra over edge weights`

