### PR TITLE
fix(decode): use spawn context for derivation_tools multiprocessing

### DIFF
--- a/deltakit-decode/src/deltakit_decode/utils/_derivation_tools.py
+++ b/deltakit-decode/src/deltakit_decode/utils/_derivation_tools.py
@@ -73,7 +73,8 @@ def _generate_expectation_data_multiprocess(
     split_samples = [
         list(islice(samples, n, n + step)) for n in range(0, len(samples), step)
     ]
-    with pathos.helpers.mp.Pool(num_processes) as p:
+    spawn_context = pathos.helpers.mp.get_context("spawn")
+    with spawn_context.Pool(num_processes) as p:
         results = p.starmap(
             _compute_combinations_of_detectors,
             [(samples, max_degree) for samples in split_samples],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,10 +142,6 @@ addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = [
   "error",
-  # Note: the below line ignore a specific warning about changes in multiprocessing.
-  # This warning is only raised by a few tests in deltakit-decode. This is a temporary
-  # fix.
-  "ignore:This process .* is multi-threaded, use of fork\\(\\) may lead to deadlocks in the child.:DeprecationWarning",
   # Note: pytest 9.1 deprecates passing a bare iterator (e.g. ``itertools.product``)
   # as parametrize argvalues. Several existing tests across the repo still do this;
   # until they are wrapped in ``list(...)`` this keeps the deprecation from being


### PR DESCRIPTION
## 🔗 Closed Issues
Closes Deltakit/deltakit-decode#7

---

## 📝 Description

Fixes `DeprecationWarning: This process is multi-threaded, use of fork() may lead to deadlocks in the child` in `deltakit-decode` when running the full monorepo test suite on Linux/WSL.

`generate_expectation_data()` used `pathos.helpers.mp.Pool`, which defaults to `fork` on Unix. When pytest has already started background threads (from earlier tests in the same process), forking triggers Python 3.12+'s deprecation warning. With root filterwarnings = ["error"], that becomes a test failure.

Changes:
- Use a local spawn multiprocessing context in `_generate_expectation_data_multiprocess()` instead of the default pool
- Remove the temporary filterwarnings ignore for this warning from root `pyproject.toml`

This follows the approach agreed in Deltakit/deltakit-decode#7: `pathos.helpers.mp.get_context("spawn")` with a per-call pool, avoiding global set_start_method() side effects.

 Verified locally (WSL):
- pytest deltakit-decode/tests/unit/utils/test_derivation_tools.py -k "num_processes or both_bool_true" - 52 passed
- Full test_derivation_tools.py - 113 passed
- `uv run --group test pytest` - 19596 passed, 9 skipped

---

## 🚦 Status

Ready for review.
- [x] Code change in _derivation_tools.py
- [x] Temporary warning filter removed from pyproject.toml
- [x] Targeted tests passing on WSL/Linux

---

## 🛠️ Future Work

None required for this PR. ProcessPool in _run_all_analysis_engine.py uses a separate code path and was out of scope for Deltakit/deltakit-decode#7.

---

## ➕️ Additional Information
- Does not reproduce on native Windows (multiprocessing defaults to spawn there)
- Reproduces on Linux/WSL when running the full test suite, not typically when running deltakit-decode/tests in isolation

---

## 🧾 Release Note

`fix(decode): use spawn context for derivation_tools multiprocessing`