### PR TITLE
Add opt-in check-redundancy meta-check DETECTORs for CSS memory circuits

### DIFF
--- a/deltakit-explorer/src/deltakit_explorer/codes/_css/_check_redundancies.py
+++ b/deltakit-explorer/src/deltakit_explorer/codes/_css/_check_redundancies.py
@@ -1,0 +1,381 @@
+# (c) Copyright Riverlane 2020-2025.
+"""
+Check-redundancy (meta-check) detectors for CSS memory circuits.
+
+When a parity-check matrix has more rows than its GF(2) rank, syndrome bits
+satisfy linear dependencies. This module emits optional DETECTOR annotations
+for those dependency products.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import galois
+import numpy as np
+from deltakit_circuit import Circuit, Detector, MeasurementRecord, PauliX, PauliZ
+from deltakit_circuit.gates import PauliBasis
+from numpy.typing import NDArray
+
+from deltakit_explorer.codes._bivariate_bicycle_code import BivariateBicycleCode
+from deltakit_explorer.codes._css._css_code import CSSCode
+from deltakit_explorer.codes._css._css_stage import CSSStage
+from deltakit_explorer.codes._css._stabiliser_code import StabiliserCode
+from deltakit_explorer.codes._stabiliser import Stabiliser
+
+
+def measurement_gate_index(num_measurements: int, record: MeasurementRecord) -> int:
+    """
+    Chronological index of a ``MeasurementRecord`` in ``measurement_gates``.
+
+    Args:
+        num_measurements: Total measurements in the circuit.
+        record: Lookback record (``rec[-1]`` is the most recent measurement).
+
+    Returns:
+        Zero-based index into ``circuit.measurement_gates``.
+    """
+    return num_measurements + record.lookback_index
+
+
+def detector_parity_matrix(
+    detectors: Sequence[Detector], num_measurements: int
+) -> NDArray[np.uint8]:
+    """
+    Build a GF(2) parity-check matrix for detector annotations.
+
+    Each row is one DETECTOR; columns follow chronological measurement order
+    (column 0 is the first ``measurement_gates`` entry).
+
+    Args:
+        detectors: Detectors to encode as rows.
+        num_measurements: Total number of measurements in the circuit.
+
+    Returns:
+        Binary matrix with shape ``(len(detectors), num_measurements)``.
+    """
+    if not detectors:
+        return np.zeros((0, num_measurements), dtype=np.uint8)
+    rows = np.zeros((len(detectors), num_measurements), dtype=np.uint8)
+    for row_index, detector in enumerate(detectors):
+        for record in detector.measurements:
+            rows[row_index, measurement_gate_index(num_measurements, record)] = 1
+    return rows
+
+
+def detector_annotation_rank(circuit: Circuit) -> int:
+    """
+    GF(2) rank of all DETECTOR parities in ``circuit``.
+
+    Args:
+        circuit: Circuit whose nested detectors are analysed.
+
+    Returns:
+        Rank of the detector parity matrix over GF(2).
+    """
+    detectors = circuit.detectors(include_nested=True)
+    parity_matrix = detector_parity_matrix(detectors, len(circuit.measurement_gates))
+    if parity_matrix.size == 0:
+        return 0
+    return int(np.linalg.matrix_rank(galois.GF2(parity_matrix)))
+
+
+def check_rank_deficit(
+    code: StabiliserCode,
+    logical_basis: PauliBasis,
+    *,
+    random_basis_side: bool = True,
+) -> int:
+    """
+    Number of independent check redundancies on a syndrome side.
+
+    Args:
+        code: CSS stabiliser code.
+        logical_basis: Z- or X-memory basis.
+        random_basis_side: If True, use the random-basis syndrome side
+            (``H_x`` for Z-memory). If False, use the deterministic side.
+
+    Returns:
+        ``num_check_rows - rank(H)`` over GF(2).
+    """
+    check_matrix = check_matrix_for_memory_basis(
+        code, logical_basis, random_basis_side=random_basis_side
+    )
+    if check_matrix.size == 0:
+        return 0
+    rank = int(np.linalg.matrix_rank(galois.GF2(check_matrix)))
+    return check_matrix.shape[0] - rank
+
+
+def left_nullspace_basis(H: NDArray[np.uint8]) -> NDArray[np.uint8]:
+    """
+    Row basis of the left nullspace of ``H`` over GF(2).
+
+    Each returned row ``λ`` satisfies ``λ @ H = 0 (mod 2)``.
+
+    Args:
+        H: Parity-check matrix.
+
+    Returns:
+        Row basis with shape ``(num_dependencies, num_rows)``.
+    """
+    if H.size == 0:
+        return np.zeros((0, H.shape[0]), dtype=np.uint8)
+    H_gf2 = galois.GF2(H)
+    rank = int(np.linalg.matrix_rank(H_gf2))
+    num_rows = H.shape[0]
+    if rank == num_rows:
+        return np.zeros((0, num_rows), dtype=np.uint8)
+    null_space = H_gf2.T.null_space()
+    return np.array(null_space, dtype=np.uint8)
+
+
+def _is_x_stabiliser(stabiliser: Stabiliser) -> bool:
+    operators = stabiliser.operator_repr
+    return bool(operators) and all(isinstance(pauli, PauliX) for pauli in operators)
+
+
+def _is_z_stabiliser(stabiliser: Stabiliser) -> bool:
+    operators = stabiliser.operator_repr
+    return bool(operators) and all(isinstance(pauli, PauliZ) for pauli in operators)
+
+
+def check_matrix_for_memory_basis(
+    code: StabiliserCode,
+    logical_basis: PauliBasis,
+    *,
+    random_basis_side: bool = True,
+) -> NDArray[np.uint8]:
+    """
+    Parity-check matrix for a syndrome side of a memory experiment.
+
+    Z-memory uses ``H_x`` on the random side and ``H_z`` on the deterministic
+    side; X-memory mirrors this.
+
+    Args:
+        code: CSS stabiliser code.
+        logical_basis: Z- or X-memory basis.
+        random_basis_side: If True, return the random-basis check matrix.
+            If False, return the deterministic-basis matrix.
+
+    Returns:
+        Parity-check matrix for the requested syndrome side.
+
+    Raises:
+        NotImplementedError: If ``code`` is not a supported CSS code type.
+    """
+    if isinstance(code, BivariateBicycleCode):
+        if logical_basis == PauliBasis.Z:
+            matrix = code.m_Hx if random_basis_side else code.m_Hz
+        else:
+            matrix = code.m_Hz if random_basis_side else code.m_Hx
+        return np.asarray(matrix, dtype=np.uint8)
+    if isinstance(code, CSSCode):
+        hx, hz = code.parity_check_matrices
+        if logical_basis == PauliBasis.Z:
+            matrix = hx if random_basis_side else hz
+        else:
+            matrix = hz if random_basis_side else hx
+        return np.asarray(matrix, dtype=np.uint8)
+    msg = (
+        "Check-redundancy emission is only implemented for CSSCode and "
+        f"BivariateBicycleCode, not {type(code).__name__}."
+    )
+    raise NotImplementedError(msg)
+
+
+def stabiliser_row_indices_for_memory_basis(
+    stabiliser_stage: CSSStage,
+    logical_basis: PauliBasis,
+    *,
+    random_basis_side: bool = True,
+) -> list[int]:
+    """
+    Ordered stabiliser indices that correspond to rows of ``check_matrix``.
+
+    Args:
+        stabiliser_stage: Syndrome measurement stage for one round.
+        logical_basis: Z- or X-memory basis.
+        random_basis_side: If True, map the random-basis stabiliser side.
+
+    Returns:
+        Stabiliser indices in ``ordered_stabilisers`` order.
+    """
+    indices: list[int] = []
+    for index, stabiliser in enumerate(stabiliser_stage.ordered_stabilisers):
+        on_random_x_side = logical_basis == PauliBasis.Z and _is_x_stabiliser(
+            stabiliser
+        )
+        on_random_z_side = logical_basis == PauliBasis.X and _is_z_stabiliser(
+            stabiliser
+        )
+        on_deterministic_z_side = logical_basis == PauliBasis.Z and _is_z_stabiliser(
+            stabiliser
+        )
+        on_deterministic_x_side = logical_basis == PauliBasis.X and _is_x_stabiliser(
+            stabiliser
+        )
+        if (random_basis_side and (on_random_x_side or on_random_z_side)) or (
+            not random_basis_side
+            and (on_deterministic_z_side or on_deterministic_x_side)
+        ):
+            indices.append(index)
+    return indices
+
+
+def first_syndrome_round_measurement_records(
+    circuit: Circuit, num_stabilisers: int
+) -> list[MeasurementRecord]:
+    """
+    Measurement records for the first full syndrome round.
+
+    The memory pipeline performs no measurements before the first syndrome
+    round, so the first ``num_stabilisers`` measurements in the circuit are
+    the first-round ancilla outcomes (in ``ordered_stabilisers`` order).
+
+    Args:
+        circuit: Full memory circuit before meta-checks are appended.
+        num_stabilisers: Number of stabilisers measured per round.
+
+    Returns:
+        First-round syndrome measurement records.
+    """
+    total_measurements = len(circuit.measurement_gates)
+    return [
+        MeasurementRecord(index - total_measurements)
+        for index in range(num_stabilisers)
+    ]
+
+
+def build_check_redundancy_detectors(
+    code: StabiliserCode,
+    circuit: Circuit,
+    logical_basis: PauliBasis,
+    num_rounds: int,
+    *,
+    random_basis_side: bool = True,
+) -> list[Detector]:
+    """
+    Build meta-check DETECTORs for check-matrix dependencies on a syndrome side.
+
+    Args:
+        code: CSS stabiliser code.
+        circuit: Full merged memory circuit before meta-checks are appended.
+        logical_basis: Z- or X-memory basis.
+        num_rounds: Number of syndrome rounds in the circuit.
+        random_basis_side: If True, emit dependencies on the random-basis side.
+            Set False only for regression testing of the deterministic side.
+
+    Returns:
+        One detector per independent check redundancy. Empty if none exist.
+
+    Raises:
+        ValueError: If the check matrix row count does not match stabiliser count.
+    """
+    del num_rounds  # first-round representatives; valid mod existing detectors
+    stabiliser_stage = code.measure_stabilisers(num_rounds=1)
+    ordered_stabilisers = stabiliser_stage.ordered_stabilisers
+    row_to_stabiliser_index = stabiliser_row_indices_for_memory_basis(
+        stabiliser_stage, logical_basis, random_basis_side=random_basis_side
+    )
+    if not row_to_stabiliser_index:
+        return []
+
+    check_matrix = check_matrix_for_memory_basis(
+        code, logical_basis, random_basis_side=random_basis_side
+    )
+    if check_matrix.shape[0] != len(row_to_stabiliser_index):
+        msg = (
+            "Check matrix row count does not match the number of stabilisers on "
+            f"the random-basis side ({check_matrix.shape[0]} vs "
+            f"{len(row_to_stabiliser_index)})."
+        )
+        raise ValueError(msg)
+
+    dependency_rows = left_nullspace_basis(check_matrix)
+    if dependency_rows.shape[0] == 0:
+        return []
+
+    first_round_records = first_syndrome_round_measurement_records(
+        circuit, len(ordered_stabilisers)
+    )
+    stabiliser_to_record = {
+        index: first_round_records[index] for index in range(len(ordered_stabilisers))
+    }
+    detector_coordinates = stabiliser_stage.detector_coordinates
+
+    detectors: list[Detector] = []
+    for dependency in dependency_rows:
+        participating = [
+            row_to_stabiliser_index[row_index]
+            for row_index, bit in enumerate(dependency)
+            if bit
+        ]
+        if len(participating) < 2:
+            continue
+        measurements = [stabiliser_to_record[index] for index in participating]
+        detectors.append(
+            Detector(
+                measurements=measurements,
+                coordinate=detector_coordinates[participating[0]],
+                tag="check_redundancy",
+            )
+        )
+    return detectors
+
+
+def append_check_redundancy_detectors(
+    circuit: Circuit,
+    code: StabiliserCode,
+    logical_basis: PauliBasis,
+    num_rounds: int,
+) -> Circuit:
+    """
+    Append optional check-redundancy DETECTOR layers to ``circuit``.
+
+    Args:
+        circuit: Memory circuit to extend in place.
+        code: CSS stabiliser code.
+        logical_basis: Z- or X-memory basis.
+        num_rounds: Number of syndrome rounds in the circuit.
+
+    Returns:
+        The same circuit, with meta-check detectors appended when present.
+    """
+    meta_detectors = build_check_redundancy_detectors(
+        code, circuit, logical_basis, num_rounds
+    )
+    if meta_detectors:
+        circuit.append_layers(meta_detectors)
+    return circuit
+
+
+def check_redundancy_record_sets(
+    code: StabiliserCode,
+    circuit: Circuit,
+    logical_basis: PauliBasis,
+    num_rounds: int,
+) -> tuple[frozenset[MeasurementRecord], ...]:
+    """
+    Return meta-check measurement-record sets without mutating a circuit.
+
+    This accessor exposes the same dependency products as
+    ``include_check_redundancies=True``, for decoder tooling that consumes
+    record sets directly rather than re-parsing Stim output.
+
+    Args:
+        code: CSS stabiliser code.
+        circuit: Base memory circuit before meta-checks are appended.
+        logical_basis: Z- or X-memory basis.
+        num_rounds: Number of syndrome rounds in the circuit.
+
+    Returns:
+        One frozenset of first-round ``MeasurementRecord`` indices per
+        independent check redundancy on the random-basis side.
+    """
+    return tuple(
+        frozenset(detector.measurements)
+        for detector in build_check_redundancy_detectors(
+            code, circuit, logical_basis, num_rounds
+        )
+    )

--- a/deltakit-explorer/src/deltakit_explorer/codes/_css/_css_code_experiment_circuit.py
+++ b/deltakit-explorer/src/deltakit_explorer/codes/_css/_css_code_experiment_circuit.py
@@ -13,6 +13,9 @@ from deltakit_circuit.gates import PauliBasis
 
 import deltakit_explorer
 from deltakit_explorer.codes._bivariate_bicycle_code import BivariateBicycleCode
+from deltakit_explorer.codes._css._check_redundancies import (
+    append_check_redundancy_detectors,
+)
 from deltakit_explorer.codes._css._experiment_circuit import experiment_circuit
 from deltakit_explorer.codes._css._stabiliser_code import StabiliserCode
 from deltakit_explorer.codes._planar_code._planar_code import PlanarCode
@@ -34,6 +37,7 @@ def css_code_memory_circuit(
     logical_basis: PauliBasis,
     client: deltakit_explorer.Client | None = None,
     use_iswap_gates: bool = False,
+    include_check_redundancies: bool = False,
 ) -> Circuit:
     """
     Return a noiseless `deltakit.circuit.Circuit` for an X or Z quantum memory experiment
@@ -53,6 +57,12 @@ def css_code_memory_circuit(
     use_iswap_gates : bool
         If you generate using cloud, you may request using
         iSWAP native gate set. Default is False.
+    include_check_redundancies : bool
+        If True, append optional DETECTOR annotations for check-matrix dependency
+        products (meta-checks) on the random-basis syndrome side. Default False
+        because dense meta-check rows can regress standard BP+OSD decoding when
+        injected into the default detector stream. Only supported for local (non-cloud)
+        circuit generation.
 
     Returns
     -------
@@ -65,6 +75,8 @@ def css_code_memory_circuit(
         If num_rounds is not positive.
     ValueError
         If logical_basis is neither PauliBasis.X nor PauliBasis.Z.
+    NotImplementedError
+        If ``include_check_redundancies`` is requested with cloud generation.
     """
     if num_rounds < 1:
         msg = "Invalid num_rounds, it has to be positive."
@@ -74,6 +86,12 @@ def css_code_memory_circuit(
         raise ValueError(msg)
     if use_iswap_gates and client is None:
         msg = "`use_iswap_gates == True` is only supported when a `client` object is provided."
+        raise NotImplementedError(msg)
+    if include_check_redundancies and client is not None:
+        msg = (
+            "`include_check_redundancies=True` is only supported for local circuit "
+            "generation (client=None)."
+        )
         raise NotImplementedError(msg)
     if client is not None:
         return _cloud_css_code_experiment_circuit(
@@ -95,9 +113,14 @@ def css_code_memory_circuit(
         if logical_basis == PauliBasis.Z
         else css_code.measure_x_logicals()
     )
-    return experiment_circuit(
+    circuit = experiment_circuit(
         experiment=[data_qubit_init_stage, stabiliser_meas_stage, data_qubit_meas_stage]
     )
+    if include_check_redundancies:
+        circuit = append_check_redundancy_detectors(
+            circuit, css_code, logical_basis, num_rounds
+        )
+    return circuit
 
 
 def _cloud_css_code_experiment_circuit(

--- a/deltakit-explorer/src/deltakit_explorer/codes/_css/_stabiliser_code.py
+++ b/deltakit-explorer/src/deltakit_explorer/codes/_css/_stabiliser_code.py
@@ -4,9 +4,12 @@ This module contains common implementation parts for stabiliser codes.
 CSSCode class derives from StabiliserCode.
 """
 
+from __future__ import annotations
+
 import itertools
 from abc import ABC, abstractmethod
 from collections.abc import Collection, Iterable, Sequence
+from typing import TYPE_CHECKING
 
 from deltakit_circuit import Qubit
 from deltakit_circuit._basic_types import PauliBasis
@@ -17,6 +20,9 @@ from deltakit_explorer.codes._css._stabiliser_helper_functions import (
     pauli_gates_to_stim_pauli_string,
 )
 from deltakit_explorer.codes._stabiliser import Stabiliser
+
+if TYPE_CHECKING:
+    from deltakit_circuit import Circuit, MeasurementRecord
 
 
 class StabiliserCode(ABC):
@@ -149,6 +155,30 @@ class StabiliserCode(ABC):
             stabilisers=self._stabilisers,
             use_ancilla_qubits=self._use_ancilla_qubits,
         )
+
+    def check_redundancy_record_sets(
+        self,
+        circuit: Circuit,
+        logical_basis: PauliBasis,
+        num_rounds: int,
+    ) -> tuple[frozenset[MeasurementRecord], ...]:
+        """
+        Return meta-check measurement-record sets for a memory circuit.
+
+        Args:
+            circuit: Base memory circuit before meta-check DETECTORs are appended.
+            logical_basis: Z- or X-memory basis.
+            num_rounds: Number of syndrome rounds in ``circuit``.
+
+        Returns:
+            One record set per independent check redundancy on the
+            random-basis syndrome side.
+        """
+        from deltakit_explorer.codes._css._check_redundancies import (  # noqa: PLC0415
+            check_redundancy_record_sets as _check_redundancy_record_sets,
+        )
+
+        return _check_redundancy_record_sets(self, circuit, logical_basis, num_rounds)
 
     @abstractmethod
     def measure_z_logicals(self) -> CSSStage:

--- a/deltakit-explorer/tests/circuit_generation/test_circuit_generation.py
+++ b/deltakit-explorer/tests/circuit_generation/test_circuit_generation.py
@@ -1,9 +1,19 @@
 import deltakit_stim as stim
+import numpy as np
 import pytest
-from deltakit_circuit.gates import PauliBasis
+from deltakit_circuit.gates import MX, PauliBasis
 
-from deltakit_explorer.codes._bivariate_bicycle_code import (
-    BivariateBicycleCode,  # noqa: F401
+from deltakit_explorer.codes._bivariate_bicycle_code import BivariateBicycleCode
+from deltakit_explorer.codes._css._check_redundancies import (
+    build_check_redundancy_detectors,
+    check_matrix_for_memory_basis,
+    check_redundancy_record_sets,
+    detector_annotation_rank,
+    detector_parity_matrix,
+    first_syndrome_round_measurement_records,
+    left_nullspace_basis,
+    measurement_gate_index,
+    stabiliser_row_indices_for_memory_basis,
 )
 from deltakit_explorer.codes._css._css_code_experiment_circuit import (
     css_code_memory_circuit,
@@ -17,6 +27,215 @@ from deltakit_explorer.codes._planar_code._unrotated_toric_code import (
     UnrotatedToricCode,
 )
 from deltakit_explorer.codes._repetition_code import RepetitionCode
+from tests.helpers._gf2 import quotient_dimension_gf2
+
+
+def _count_detectors(circuit) -> int:
+    return len(circuit.detectors(include_nested=True))
+
+
+def _count_check_redundancy_detectors(circuit) -> int:
+    return sum(
+        1
+        for detector in circuit.detectors(include_nested=True)
+        if detector.tag == "check_redundancy"
+    )
+
+
+def _meta_check_detectors(circuit):
+    return [
+        detector
+        for detector in circuit.detectors(include_nested=True)
+        if detector.tag == "check_redundancy"
+    ]
+
+
+@pytest.fixture
+def bb_72_12_6_code():
+    return BivariateBicycleCode(
+        param_l=6,
+        param_m=6,
+        m_A_powers=[3, 1, 2],
+        m_B_powers=[3, 1, 2],
+    )
+
+
+@pytest.mark.parametrize(
+    ("param_l", "param_m", "m_A_powers", "m_B_powers", "expected_meta"),
+    [
+        (6, 6, [3, 1, 2], [3, 1, 2], 6),
+        (15, 3, [9, 1, 2], [0, 2, 7], 4),
+        (9, 6, [3, 1, 2], [3, 1, 2], 4),
+    ],
+)
+@pytest.mark.parametrize("num_rounds", [1, 2, 3])
+@pytest.mark.parametrize("basis", [PauliBasis.Z, PauliBasis.X])
+def test_bb_check_redundancy_opt_in(
+    param_l, param_m, m_A_powers, m_B_powers, expected_meta, num_rounds, basis
+):
+    code = BivariateBicycleCode(
+        param_l=param_l,
+        param_m=param_m,
+        m_A_powers=m_A_powers,
+        m_B_powers=m_B_powers,
+    )
+    default_circuit = css_code_memory_circuit(
+        code, num_rounds=num_rounds, logical_basis=basis
+    )
+    opt_in_circuit = css_code_memory_circuit(
+        code,
+        num_rounds=num_rounds,
+        logical_basis=basis,
+        include_check_redundancies=True,
+    )
+    assert _count_detectors(default_circuit) + expected_meta == _count_detectors(
+        opt_in_circuit
+    )
+    assert _count_check_redundancy_detectors(opt_in_circuit) == expected_meta
+    assert _count_check_redundancy_detectors(default_circuit) == 0
+
+
+def test_planar_code_default_unchanged_with_opt_in_flag():
+    code = RotatedPlanarCode(width=3, height=3)
+    default_circuit = css_code_memory_circuit(code, 3, PauliBasis.Z)
+    opt_in_circuit = css_code_memory_circuit(
+        code, 3, PauliBasis.Z, include_check_redundancies=True
+    )
+    assert default_circuit.as_stim_circuit() == opt_in_circuit.as_stim_circuit()
+
+
+def test_left_nullspace_toy_dependency():
+    H = np.array(
+        [
+            [1, 1, 0, 0],
+            [0, 1, 1, 0],
+            [1, 0, 1, 0],
+            [1, 1, 1, 1],
+        ],
+        dtype=np.uint8,
+    )
+    basis = left_nullspace_basis(H)
+    assert basis.shape == (1, 4)
+    assert (basis[0] == np.array([1, 1, 1, 0], dtype=np.uint8)).all()
+
+
+def test_bb_meta_detector_fan_in(bb_72_12_6_code):
+    code = bb_72_12_6_code
+    circuit = css_code_memory_circuit(code, 3, PauliBasis.Z)
+    meta = build_check_redundancy_detectors(code, circuit, PauliBasis.Z, 3)
+    assert len(meta) == 6
+    fan_ins = [len(detector.measurements) for detector in meta]
+    assert min(fan_ins) >= 16
+    assert max(fan_ins) <= 18
+
+
+def test_bb_meta_checks_use_first_round_mx_records(bb_72_12_6_code):
+    code = bb_72_12_6_code
+    circuit = css_code_memory_circuit(code, 3, PauliBasis.Z)
+    measurement_gates = circuit.measurement_gates
+    num_measurements = len(measurement_gates)
+    meta = build_check_redundancy_detectors(code, circuit, PauliBasis.Z, 3)
+    for detector in meta:
+        for record in detector.measurements:
+            gate = measurement_gates[measurement_gate_index(num_measurements, record)]
+            assert isinstance(gate, MX)
+
+
+def test_bb_check_matrix_side_for_z_memory(bb_72_12_6_code):
+    code = bb_72_12_6_code
+    hx = check_matrix_for_memory_basis(code, PauliBasis.Z, random_basis_side=True)
+    hz = check_matrix_for_memory_basis(code, PauliBasis.Z, random_basis_side=False)
+    np.testing.assert_array_equal(hx, code.m_Hx)
+    np.testing.assert_array_equal(hz, code.m_Hz)
+    assert not np.array_equal(hx, hz)
+
+
+def test_bb_meta_checks_increase_annotation_rank(bb_72_12_6_code):
+    code = bb_72_12_6_code
+    default_circuit = css_code_memory_circuit(code, 3, PauliBasis.Z)
+    opt_in_circuit = css_code_memory_circuit(
+        code, 3, PauliBasis.Z, include_check_redundancies=True
+    )
+    assert (
+        detector_annotation_rank(opt_in_circuit)
+        == detector_annotation_rank(default_circuit) + 6
+    )
+
+
+def test_bb_meta_checks_outside_default_detector_span(bb_72_12_6_code):
+    code = bb_72_12_6_code
+    default_circuit = css_code_memory_circuit(code, 3, PauliBasis.Z)
+    opt_in_circuit = css_code_memory_circuit(
+        code, 3, PauliBasis.Z, include_check_redundancies=True
+    )
+    num_measurements = len(default_circuit.measurement_gates)
+    default_matrix = detector_parity_matrix(
+        default_circuit.detectors(include_nested=True), num_measurements
+    )
+    meta_matrix = detector_parity_matrix(
+        _meta_check_detectors(opt_in_circuit), num_measurements
+    )
+    assert quotient_dimension_gf2(meta_matrix, default_matrix) == 6
+
+
+def test_bb_wrong_side_record_sets_differ_from_correct(bb_72_12_6_code):
+    code = bb_72_12_6_code
+    circuit = css_code_memory_circuit(code, 3, PauliBasis.Z)
+    correct_sets = check_redundancy_record_sets(code, circuit, PauliBasis.Z, 3)
+    wrong_sets = tuple(
+        frozenset(detector.measurements)
+        for detector in build_check_redundancy_detectors(
+            code, circuit, PauliBasis.Z, 3, random_basis_side=False
+        )
+    )
+    assert len(wrong_sets) == 6
+    assert wrong_sets != correct_sets
+
+
+def test_bb_hz_matrix_with_x_records_differs_from_correct_meta(bb_72_12_6_code):
+    code = bb_72_12_6_code
+    circuit = css_code_memory_circuit(code, 3, PauliBasis.Z)
+    correct_sets = check_redundancy_record_sets(code, circuit, PauliBasis.Z, 3)
+    stage = code.measure_stabilisers(num_rounds=1)
+    x_rows = stabiliser_row_indices_for_memory_basis(
+        stage, PauliBasis.Z, random_basis_side=True
+    )
+    hz = check_matrix_for_memory_basis(code, PauliBasis.Z, random_basis_side=False)
+    records = first_syndrome_round_measurement_records(
+        circuit, len(stage.ordered_stabilisers)
+    )
+    stabiliser_to_record = {
+        index: records[index] for index in range(len(stage.ordered_stabilisers))
+    }
+    side_bug_sets = []
+    for dependency in left_nullspace_basis(hz):
+        participating = [
+            x_rows[row_index] for row_index, bit in enumerate(dependency) if bit
+        ]
+        if len(participating) >= 2:
+            side_bug_sets.append(
+                frozenset(stabiliser_to_record[index] for index in participating)
+            )
+    assert len(side_bug_sets) == 6
+    assert side_bug_sets != list(correct_sets)
+
+
+def test_bb_opt_in_detector_error_model_compiles(bb_72_12_6_code):
+    code = bb_72_12_6_code
+    opt_in_circuit = css_code_memory_circuit(
+        code, 3, PauliBasis.Z, include_check_redundancies=True
+    )
+    opt_in_circuit.as_stim_circuit().detector_error_model(decompose_errors=True)
+
+
+def test_bb_check_redundancy_record_sets_accessor(bb_72_12_6_code):
+    code = bb_72_12_6_code
+    circuit = css_code_memory_circuit(code, 3, PauliBasis.Z)
+    record_sets = code.check_redundancy_record_sets(circuit, PauliBasis.Z, 3)
+    assert record_sets == check_redundancy_record_sets(code, circuit, PauliBasis.Z, 3)
+    assert len(record_sets) == 6
+    built = build_check_redundancy_detectors(code, circuit, PauliBasis.Z, 3)
+    assert record_sets == tuple(frozenset(detector.measurements) for detector in built)
 
 
 @pytest.fixture


### PR DESCRIPTION
## 🔗 Closed Issues

Closes #312
  
---

## 📝 Description

`css_code_memory_circuit` on bivariate-bicycle and other CSS codes with redundant check rows emits DETECTOR annotations that span every deterministic measurement parity **except** the first-round dependency products on the random-basis syndrome side (e.g. six missing parities on [[72,12,6]] Z-memory: rank deficit of the 36 X-check rows). Those products are deterministic, payload-independent, and useful for single-shot decoding and syndrome-validation workflows, but were not previously exposed in the emitted circuit artifact.

This PR adds **opt-in** support for those meta-checks:
- **`include_check_redundancies=False`** (default) on `css_code_memory_circuit`, behaviour unchanged.
- **`include_check_redundancies=True`**, appends extra DETECTORs tagged `check_redundancy`, one per independent GF(2) left-nullspace dependency of the random-basis check matrix, using first-round syndrome `MeasurementRecord`s.
- **`StabiliserCode.check_redundancy_record_sets(...)`**, accessor returning the same redundancy basis as frozensets of measurement records, for consumers that prefer to attach parities outside the default detector stream.

**Side selection (per issue discussion):** Z-memory -> `H_x` / X-ancilla (random side); X-memory -> `H_z` / Z-ancilla.

**Scope limits:**
- Local circuit generation only (`client=None`); cloud path raises `NotImplementedError` if the flag is set.
- Default emission deliberately unchanged: dense meta-check rows (fan-in 16–18 on BB codes) can regress stock circuit-level BP+OSD at small round counts when injected into the default stream.

**Implementation:** new module `_check_redundancies.py` with GF(2) nullspace computation, matrix/side selection, detector construction, and test helpers (`detector_parity_matrix`, `detector_annotation_rank`, etc.).
**Tests** cover [[72,12,6]], [[90,8,10]], [[108,8,10]] across Z/X memory and multiple round counts; rank/span accounting; correct matrix side vs regression guards; planar code unchanged; Stim DEM compilation; accessor consistency.

---

## 🚦 Status
- [x] Opt-in flag and accessor implemented
- [x] Unit tests added and passing locally
- [x] Default circuit output unchanged when flag is `False`

---

## 🛠️ Future Work
- Cloud circuit generation support for `include_check_redundancies=True` ([#312 follow-up}(https://github.com/Deltakit/deltakit/issues/312), out of scope here).
- User-facing note in `docs/guide/circuit_generation.md` describing when and why to enable meta-checks.
- Extend beyond `BivariateBicycleCode` / `CSSCode` if other `StabiliserCode` subclasses need the same path (currently raises `NotImplementedError` for unsupported types).
- Optional integration examples for decoders that consume meta-check record sets directly.

---

## ➕️ Additional Information

Meta-check DETECTORs are appended **after** the standard memory pipeline stages; they do not alter the underlying measurement schedule. Codes with full-rank check matrices (e.g. rotated planar surface code) produce no extra detectors even when the flag is `True`.

Tagged detectors (`tag="check_redundancy"`) can be filtered by downstream tooling without parsing parity structure.

---

## 🧾 Release Note
Add opt-in check-redundancy meta-check DETECTORs for CSS memory circuits (`include_check_redundancies` on `css_code_memory_circuit`; `check_redundancy_record_sets` on `StabiliserCode`). Default behaviour unchanged.