### PR TITLE
docs: documents standalone component repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,15 +77,16 @@ For any usage questions or comments, visit our [Q&A forum](https://github.com/De
 
 Deltakit is developed across the following standalone component repositories:
 
-| Repository                                                             | Description                                                                               |
-|------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
-| [`deltakit-circuit`](https://github.com/Deltakit/deltakit-circuit)     | Circuit representations, gates, noise channels and Stim conversion utilities.             |
-| [`deltakit-core`](https://github.com/Deltakit/deltakit-core)           | Shared data formats and decoding graph utilities.                                         |
-| [`deltakit-decode`](https://github.com/Deltakit/deltakit-decode)       | Decoders, decoding workflows, noise sources and decoding analysis utilities.              |
-| [`deltakit-explorer`](https://github.com/Deltakit/deltakit-explorer)   | Tools for constructing, simulating, analysing and visualising QEC experiments.            |
-| [`deltakit-compile`](https://github.com/Deltakit/deltakit-compile)     | Compiler infrastructure for Deltakit.                                                     |
-| [`deltakit-visualise`](https://github.com/Deltakit/deltakit-visualise) | Python visualisation and debugging tools for QEC programs compiled by `deltakit-compile`. |
-| [`deltakit-vis`](https://github.com/Deltakit/deltakit-vis)             | Frontend rendering library used by `deltakit-visualise`.                                  |
+| Repository                                                             | Description                                                                                                                     |
+|------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| [`deltakit-circuit`](https://github.com/Deltakit/deltakit-circuit)     | Circuit representations, gates, noise channels and [Stim](https://github.com/quantumlib/Stim) conversion utilities.                                               |
+| [`deltakit-core`](https://github.com/Deltakit/deltakit-core)           | Shared data formats and decoding graph utilities.                                                                               |
+| [`deltakit-decode`](https://github.com/Deltakit/deltakit-decode)       | Decoders, decoding workflows, noise sources and decoding analysis utilities.                                                    |
+| [`deltakit-explorer`](https://github.com/Deltakit/deltakit-explorer)   | Tools for constructing, simulating, analysing and visualising QEC experiments.                                                  |
+| [`deltakit-compile`](https://github.com/Deltakit/deltakit-compile)     | Compiler infrastructure for Deltakit.                                                                                           |
+| [`deltakit-visualise`](https://github.com/Deltakit/deltakit-visualise) | Python visualisation and debugging tools for QEC programs compiled by `deltakit-compile`.                                       |
+| [`deltakit-vis`](https://github.com/Deltakit/deltakit-vis)             | Frontend rendering library used by `deltakit-visualise`.                                                                        |
+| [`deltakit-stim`](https://github.com/Deltakit/deltakit-stim)           | [Stim](https://github.com/quantumlib/Stim) fork supporting non-computational leakage errors and adaptive detector error models. |
 
 ## Feature highlights
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ For more detailed information, check out the [Deltakit documentation](https://de
 
 For any usage questions or comments, visit our [Q&A forum](https://github.com/Deltakit/deltakit/discussions/categories/q-a).
 
+## Component repositories
+
+Deltakit is developed across the following standalone component repositories:
+
+| Repository                                                             | Description                                                                               |
+|------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| [`deltakit-circuit`](https://github.com/Deltakit/deltakit-circuit)     | Circuit representations, gates, noise channels and Stim conversion utilities.             |
+| [`deltakit-core`](https://github.com/Deltakit/deltakit-core)           | Shared data formats and decoding graph utilities.                                         |
+| [`deltakit-decode`](https://github.com/Deltakit/deltakit-decode)       | Decoders, decoding workflows, noise sources and decoding analysis utilities.              |
+| [`deltakit-explorer`](https://github.com/Deltakit/deltakit-explorer)   | Tools for constructing, simulating, analysing and visualising QEC experiments.            |
+| [`deltakit-compile`](https://github.com/Deltakit/deltakit-compile)     | Compiler infrastructure for Deltakit.                                                     |
+| [`deltakit-visualise`](https://github.com/Deltakit/deltakit-visualise) | Python visualisation and debugging tools for QEC programs compiled by `deltakit-compile`. |
+| [`deltakit-vis`](https://github.com/Deltakit/deltakit-vis)             | Frontend rendering library used by `deltakit-visualise`.                                  |
+
 ## Feature highlights
 
 Standard QEC experiments proceed through several fundamental stages, each of which is facilitated by the functionality provided in the `deltakit` package:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Issues contributions concern reporting a behavioural discrepancy in the code bas
 
 ## Submitting a Pull Request
 
-Issues can be resolved by submitting a Pull Request (PR). The recommended workflow is to first fork the main branch using the GitHub interface (via the Fork button in the top-right corner). This creates a new repository under your GitHub account, prefixed with your GitHub handle.
+Issues can be resolved by submitting a Pull Request (PR). The recommended workflow is to first fork the main branch using the GitHub interface (via the Fork button in the top-right corner). This creates a new repository under your GitHub account, prefixed with your GitHub handle.Resolving an issue is possible by submitting a Pull Request (PR). The recommended process is to fork the `main` branch using GitHub interface button on the top-right corner. This will create a new GitHub repository prefixed with your GitHub handle.
 
 Clone your fork locally:
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Issues contributions concern reporting a behavioural discrepancy in the code bas
 
 ## Submitting a Pull Request
 
-Issues can be resolved by submitting a Pull Request (PR). The recommended workflow is to first fork the main branch using the GitHub interface (via the Fork button in the top-right corner). This creates a new repository under your GitHub account, prefixed with your GitHub handle.Resolving an issue is possible by submitting a Pull Request (PR). The recommended process is to fork the `main` branch using GitHub interface button on the top-right corner. This will create a new GitHub repository prefixed with your GitHub handle.
+Issues can be resolved by submitting a Pull Request (PR). The recommended workflow is to first fork the main branch using the GitHub interface (via the Fork button in the top-right corner). This creates a new repository under your GitHub account, prefixed with your GitHub handle.
 
 Clone your fork locally:
 


### PR DESCRIPTION
## 🔗 Closed Issues

Closes #337.

---

## 📝 Description

Documents the standalone Deltakit component repositories in the main README.

Adds a concise table linking each repository and summarising its responsibility.

---

## 🚦 Status

Ready to review.

---

## 🛠️ Future Work

N/A.

---

## ➕️ Additional Information

Validation performed:

* Confirmed that all eight repository links return HTTP 200.
* Rendered the README as GitHub-flavored Markdown and verified the table structure.
* Ran `git diff --check` and `typos README.md`.

AI assistance: AI was used to help draft the README table and PR text. I reviewed the final diff, made some changes, verified the links and rendered output locally.

---

## 🧾 Release Note

docs: documents standalone component repositories